### PR TITLE
feat: add internal/worktree leaf package (issue #6)

### DIFF
--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -9,13 +9,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-)
 
-type Worktree struct {
-	Path   string
-	Branch string // stripped of refs/heads/ prefix; "(detached)" when detached
-	IsMain bool   // true when .git entry is a directory, not a file
-}
+	"treepad/internal/worktree"
+)
 
 type CommandRunner interface {
 	Run(ctx context.Context, name string, args ...string) ([]byte, error)
@@ -27,7 +23,7 @@ func (ExecRunner) Run(ctx context.Context, name string, args ...string) ([]byte,
 	return exec.CommandContext(ctx, name, args...).Output()
 }
 
-func List(ctx context.Context, runner CommandRunner) ([]Worktree, error) {
+func List(ctx context.Context, runner CommandRunner) ([]worktree.Worktree, error) {
 	out, err := runner.Run(ctx, "git", "worktree", "list", "--porcelain")
 	if err != nil {
 		return nil, fmt.Errorf("git worktree list: %w", err)
@@ -36,20 +32,20 @@ func List(ctx context.Context, runner CommandRunner) ([]Worktree, error) {
 }
 
 // MainWorktree returns the worktree whose .git entry is a directory (the main repo).
-func MainWorktree(worktrees []Worktree) (Worktree, error) {
-	for _, wt := range worktrees {
+func MainWorktree(wts []worktree.Worktree) (worktree.Worktree, error) {
+	for _, wt := range wts {
 		if wt.IsMain {
 			return wt, nil
 		}
 	}
-	return Worktree{}, fmt.Errorf("could not find main worktree (no .git directory found)")
+	return worktree.Worktree{}, fmt.Errorf("could not find main worktree (no .git directory found)")
 }
 
 // parsePorcelain parses `git worktree list --porcelain` output.
 // Entries are blank-line separated; each entry contains key-value pairs.
-func parsePorcelain(data []byte) ([]Worktree, error) {
-	var worktrees []Worktree
-	var current Worktree
+func parsePorcelain(data []byte) ([]worktree.Worktree, error) {
+	var worktrees []worktree.Worktree
+	var current worktree.Worktree
 	inEntry := false
 
 	scanner := bufio.NewScanner(bytes.NewReader(data))
@@ -58,7 +54,7 @@ func parsePorcelain(data []byte) ([]Worktree, error) {
 		if line == "" {
 			if inEntry {
 				worktrees = append(worktrees, current)
-				current = Worktree{}
+				current = worktree.Worktree{}
 				inEntry = false
 			}
 			continue

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	"treepad/internal/worktree"
 )
 
 // stubRunner satisfies CommandRunner and returns fixed output.
@@ -93,7 +95,7 @@ branch refs/heads/main`)
 }
 
 func TestMainWorktree(t *testing.T) {
-	worktrees := []Worktree{
+	worktrees := []worktree.Worktree{
 		{Path: "/a", Branch: "feature", IsMain: false},
 		{Path: "/b", Branch: "main", IsMain: true},
 	}
@@ -107,7 +109,7 @@ func TestMainWorktree(t *testing.T) {
 }
 
 func TestMainWorktree_noneFound(t *testing.T) {
-	_, err := MainWorktree([]Worktree{{Path: "/a", IsMain: false}})
+	_, err := MainWorktree([]worktree.Worktree{{Path: "/a", IsMain: false}})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"treepad/internal/git"
+	"treepad/internal/worktree"
 )
 
 type Config struct {
@@ -68,7 +68,7 @@ func (FileSyncer) SyncEnvFiles(cfg Config) error {
 	return nil
 }
 
-func SyncAll(syncer Syncer, source string, worktrees []git.Worktree) error {
+func SyncAll(syncer Syncer, source string, worktrees []worktree.Worktree) error {
 	srcAbs, err := filepath.Abs(source)
 	if err != nil {
 		return fmt.Errorf("resolve source path: %w", err)

--- a/internal/vscode/workspace.go
+++ b/internal/vscode/workspace.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"treepad/internal/git"
+	"treepad/internal/worktree"
 )
 
 type workspaceFolder struct {
@@ -22,7 +22,7 @@ type workspaceFile struct {
 
 // Generate writes one .code-workspace file per worktree into outputDir.
 // Files are named <slug>-<branch>.code-workspace.
-func Generate(worktrees []git.Worktree, extensions []string, slug, outputDir string) error {
+func Generate(worktrees []worktree.Worktree, extensions []string, slug, outputDir string) error {
 	if err := os.MkdirAll(outputDir, 0o755); err != nil {
 		return fmt.Errorf("create output dir: %w", err)
 	}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -1,0 +1,10 @@
+// Package worktree defines the shared Worktree value type used across packages.
+// It has no project-internal imports and must never acquire any.
+package worktree
+
+// Worktree represents a single git worktree checkout on disk.
+type Worktree struct {
+	Path   string
+	Branch string // stripped of refs/heads/ prefix; "(detached)" when detached
+	IsMain bool   // true when .git entry is a directory, not a file
+}


### PR DESCRIPTION
## Summary

- Introduces `internal/worktree` as a zero-dependency leaf package containing only the `Worktree` value type
- `internal/git`, `internal/vscode`, and `internal/sync` all import `internal/worktree` directly — no type alias, no conversion
- `internal/vscode` and `internal/sync` no longer import `internal/git` at all

## Why

`git.Worktree` was leaking into `internal/vscode` and `internal/sync`, coupling packages that perform editor/file-sync operations to the git execution package. Using `worktree.Worktree` directly (rather than an alias) keeps the type visible and avoids an unnecessary indirection layer.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes — existing git package tests unchanged
- [x] `internal/worktree` has no project-internal imports
- [x] `internal/vscode` and `internal/sync` no longer import `internal/git`

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)