### PR TITLE
feat: editor adapter port — decouple workspace command from VS Code (issue #3)

### DIFF
--- a/cmd/workspace/workspace.go
+++ b/cmd/workspace/workspace.go
@@ -8,16 +8,16 @@ import (
 
 	"github.com/urfave/cli/v3"
 
+	"treepad/internal/editor"
 	"treepad/internal/git"
 	"treepad/internal/slug"
-	internalsync "treepad/internal/sync"
-	"treepad/internal/vscode"
+	_ "treepad/internal/vscode" // registers the "vscode" adapter
 )
 
 func Command() *cli.Command {
 	return &cli.Command{
 		Name:      "workspace",
-		Usage:     "sync VS Code configs and generate .code-workspace files across git worktrees",
+		Usage:     "sync editor configs and generate workspace files across git worktrees",
 		ArgsUsage: "[source-path]",
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
@@ -27,12 +27,17 @@ func Command() *cli.Command {
 			},
 			&cli.BoolFlag{
 				Name:  "sync-only",
-				Usage: "sync configs to all worktrees; skip .code-workspace file generation",
+				Usage: "sync configs to all worktrees; skip workspace file generation",
 			},
 			&cli.StringFlag{
 				Name:    "output-dir",
 				Aliases: []string{"o"},
-				Usage:   "directory for generated .code-workspace files (default: ~/<repo-slug>-workspaces/)",
+				Usage:   "directory for generated workspace files (default: ~/<repo-slug>-workspaces/)",
+			},
+			&cli.StringFlag{
+				Name:  "editor",
+				Value: "vscode",
+				Usage: "editor adapter to use",
 			},
 		},
 		Action: run,
@@ -80,49 +85,34 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	repoSlug := slug.Slug(filepath.Base(sourceDir))
-	syncOnly := cmd.Bool("sync-only")
 
-	if !syncOnly {
-		outputDir := cmd.String("output-dir")
-		if outputDir == "" {
-			home, err := os.UserHomeDir()
-			if err != nil {
-				return fmt.Errorf("get home directory: %w", err)
-			}
-			outputDir = filepath.Join(home, repoSlug+"-workspaces")
-		}
-
-		extensions, err := resolveExtensions(sourceDir)
+	outputDir := cmd.String("output-dir")
+	if outputDir == "" {
+		home, err := os.UserHomeDir()
 		if err != nil {
-			return err
+			return fmt.Errorf("get home directory: %w", err)
 		}
-
-		fmt.Printf("\ngenerating workspace files → %s\n", outputDir)
-		if err := vscode.Generate(worktrees, extensions, repoSlug, outputDir); err != nil {
-			return err
-		}
+		outputDir = filepath.Join(home, repoSlug+"-workspaces")
 	}
 
-	fmt.Println("\nsyncing configs to worktrees...")
-	if err := internalsync.SyncAll(internalsync.FileSyncer{}, sourceDir, worktrees); err != nil {
+	ad, err := editor.New(cmd.String("editor"))
+	if err != nil {
 		return err
 	}
 
-	if syncOnly {
+	if err := ad.Configure(worktrees, editor.Options{
+		SourceDir: sourceDir,
+		OutputDir: outputDir,
+		Slug:      repoSlug,
+		SyncOnly:  cmd.Bool("sync-only"),
+	}); err != nil {
+		return err
+	}
+
+	if cmd.Bool("sync-only") {
 		fmt.Println("\ndone: config sync complete")
 	} else {
 		fmt.Println("\ndone: workspace files generated and configs synced")
 	}
 	return nil
-}
-
-func resolveExtensions(dir string) ([]string, error) {
-	exts, err := vscode.ReadExtensions(dir)
-	if err != nil {
-		return nil, err
-	}
-	if exts != nil {
-		return exts, nil
-	}
-	return vscode.DetectExtensions(dir)
 }

--- a/internal/editor/adapter.go
+++ b/internal/editor/adapter.go
@@ -1,0 +1,21 @@
+package editor
+
+import "treepad/internal/worktree"
+
+// Adapter is the port that each editor implements.
+// Configure applies all editor-specific setup (workspace file generation,
+// config syncing, plugin recommendations) for every worktree.
+// It is idempotent — safe to call repeatedly.
+type Adapter interface {
+	Configure(worktrees []worktree.Worktree, opts Options) error
+	Name() string
+}
+
+// Options carries everything an adapter might need.
+// The command layer populates this; adapters use what they require.
+type Options struct {
+	SourceDir string
+	OutputDir string
+	Slug      string
+	SyncOnly  bool
+}

--- a/internal/editor/registry.go
+++ b/internal/editor/registry.go
@@ -1,0 +1,35 @@
+package editor
+
+import (
+	"fmt"
+	"sort"
+)
+
+type factory func() Adapter
+
+var registry = map[string]factory{}
+
+// Register adds an adapter constructor under a stable name.
+// Called from each adapter package's init() function.
+func Register(name string, f factory) {
+	registry[name] = f
+}
+
+// New returns an Adapter for the given name, or an error listing available adapters.
+func New(name string) (Adapter, error) {
+	f, ok := registry[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown editor %q — available: %v", name, Available())
+	}
+	return f(), nil
+}
+
+// Available returns a sorted list of registered editor names.
+func Available() []string {
+	names := make([]string, 0, len(registry))
+	for name := range registry {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/vscode/adapter.go
+++ b/internal/vscode/adapter.go
@@ -1,0 +1,46 @@
+package vscode
+
+import (
+	"fmt"
+
+	"treepad/internal/editor"
+	"treepad/internal/sync"
+	"treepad/internal/worktree"
+)
+
+func init() {
+	editor.Register("vscode", func() editor.Adapter { return &Adapter{} })
+}
+
+type Adapter struct{}
+
+func (a *Adapter) Name() string { return "vscode" }
+
+func (a *Adapter) Configure(worktrees []worktree.Worktree, opts editor.Options) error {
+	if !opts.SyncOnly {
+		extensions, err := resolveExtensions(opts.SourceDir)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("\ngenerating workspace files → %s\n", opts.OutputDir)
+		if err := Generate(worktrees, extensions, opts.Slug, opts.OutputDir); err != nil {
+			return err
+		}
+	}
+
+	fmt.Println("\nsyncing configs to worktrees...")
+	syncer := sync.FileSyncer{}
+	return sync.SyncAll(syncer, opts.SourceDir, worktrees)
+}
+
+func resolveExtensions(dir string) ([]string, error) {
+	exts, err := ReadExtensions(dir)
+	if err != nil {
+		return nil, err
+	}
+	if exts != nil {
+		return exts, nil
+	}
+	return DetectExtensions(dir)
+}


### PR DESCRIPTION
## Summary

- New `internal/editor` package: `Adapter` interface, `Options` type, `init()`-based registry (`Register`, `New`, `Available`)
- New `internal/vscode/adapter.go`: VS Code registers itself as `"vscode"` via `init()`; wraps existing `Generate`, `ReadExtensions`, `DetectExtensions`, and `SyncAll` — no existing files modified
- `cmd/workspace`: adds `--editor` flag (default `"vscode"`), resolves adapter by name, delegates all work to `adapter.Configure` — direct calls to `vscode.*` and `internalsync.SyncAll` removed from command layer

## Why

The command layer was hardcoded to VS Code. Adding a second editor would have required branching `if editor == "vscode"` logic scattered through `run()`. The adapter port means adding JetBrains or Zed is a new package + one blank import — zero changes to the command layer or any existing code.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `--editor vscode` resolves correctly via registry
- [x] `--editor unknown` returns a descriptive error listing available editors
- [x] Existing sync and workspace generation behaviour unchanged

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)