### PR TITLE
feat: data-driven sync config — replace hardcoded file list (issue #4)

### DIFF
--- a/cmd/workspace/workspace.go
+++ b/cmd/workspace/workspace.go
@@ -8,9 +8,11 @@ import (
 
 	"github.com/urfave/cli/v3"
 
+	"treepad/internal/config"
 	"treepad/internal/editor"
 	"treepad/internal/git"
 	"treepad/internal/slug"
+	"treepad/internal/sync"
 	_ "treepad/internal/vscode" // registers the "vscode" adapter
 )
 
@@ -38,6 +40,10 @@ func Command() *cli.Command {
 				Name:  "editor",
 				Value: "vscode",
 				Usage: "editor adapter to use",
+			},
+			&cli.StringSliceFlag{
+				Name:  "include",
+				Usage: "additional file patterns to sync (appended to sync.files in .treepad.json)",
 			},
 		},
 		Action: run,
@@ -107,6 +113,27 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		SyncOnly:  cmd.Bool("sync-only"),
 	}); err != nil {
 		return err
+	}
+
+	treePadCfg, err := config.Load(sourceDir)
+	if err != nil {
+		return err
+	}
+	patterns := append(treePadCfg.Sync.Files, cmd.StringSlice("include")...)
+
+	fmt.Println("\nsyncing tool configs to worktrees...")
+	syncer := sync.FileSyncer{}
+	for _, wt := range worktrees {
+		if wt.Path == sourceDir {
+			continue
+		}
+		fmt.Printf("  → %s (%s)\n", wt.Branch, wt.Path)
+		if err := syncer.Sync(patterns, sync.Config{
+			SourceDir: sourceDir,
+			TargetDir: wt.Path,
+		}); err != nil {
+			return fmt.Errorf("sync tool configs to %s: %w", wt.Branch, err)
+		}
 	}
 
 	if cmd.Bool("sync-only") {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,62 @@
+// Package config loads optional per-repo configuration from .treepad.json.
+// All fields have sane defaults so the file is never required.
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const configFileName = ".treepad.json"
+
+// DefaultSyncFiles is the baseline list of tool-agnostic files synced across
+// worktrees when no .treepad.json is present or when sync.files is unset.
+var DefaultSyncFiles = []string{
+	".claude/settings.local.json",
+	".env",
+	".env.docker-compose",
+}
+
+type SyncConfig struct {
+	// Files replaces DefaultSyncFiles entirely when non-empty.
+	Files []string `json:"files"`
+}
+
+type Config struct {
+	// Editor sets the default adapter name; overridden by the --editor flag.
+	Editor string     `json:"editor"`
+	Sync   SyncConfig `json:"sync"`
+}
+
+// Load reads .treepad.json from repoRoot. Returns defaults when the file is absent.
+func Load(repoRoot string) (Config, error) {
+	cfg := Config{
+		Editor: "vscode",
+		Sync:   SyncConfig{Files: DefaultSyncFiles},
+	}
+
+	data, err := os.ReadFile(filepath.Join(repoRoot, configFileName))
+	if errors.Is(err, os.ErrNotExist) {
+		return cfg, nil
+	}
+	if err != nil {
+		return cfg, fmt.Errorf("reading %s: %w", configFileName, err)
+	}
+
+	var fileCfg Config
+	if err := json.Unmarshal(data, &fileCfg); err != nil {
+		return cfg, fmt.Errorf("parsing %s: %w", configFileName, err)
+	}
+
+	if fileCfg.Editor != "" {
+		cfg.Editor = fileCfg.Editor
+	}
+	if len(fileCfg.Sync.Files) > 0 {
+		cfg.Sync.Files = fileCfg.Sync.Files
+	}
+
+	return cfg, nil
+}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -1,111 +1,47 @@
 package sync
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
-
-	"treepad/internal/worktree"
 )
 
+// Config holds the source and target directories for a single sync operation.
 type Config struct {
 	SourceDir string
 	TargetDir string
 }
 
+// Syncer copies files matching patterns from SourceDir to TargetDir.
+// Patterns are relative paths or globs anchored at SourceDir.
+// Files absent in SourceDir are silently skipped.
 type Syncer interface {
-	SyncVSCode(cfg Config) error
-	SyncClaudeSettings(cfg Config) error
-	SyncEnvFiles(cfg Config) error
+	Sync(patterns []string, cfg Config) error
 }
 
 type FileSyncer struct{}
 
-// SyncVSCode copies settings.json as-is from source; callers are responsible for filtering it first.
-func (FileSyncer) SyncVSCode(cfg Config) error {
-	srcDir := filepath.Join(cfg.SourceDir, ".vscode")
-	dstDir := filepath.Join(cfg.TargetDir, ".vscode")
-
-	static := []string{"settings.json", "tasks.json", "launch.json", "extensions.json"}
-	for _, name := range static {
-		if err := copyFile(filepath.Join(srcDir, name), filepath.Join(dstDir, name)); err != nil {
-			return fmt.Errorf("sync .vscode/%s: %w", name, err)
-		}
-	}
-
-	snippets, err := filepath.Glob(filepath.Join(srcDir, "*.code-snippets"))
-	if err != nil {
-		return fmt.Errorf("glob code-snippets: %w", err)
-	}
-	for _, src := range snippets {
-		dst := filepath.Join(dstDir, filepath.Base(src))
-		if err := copyFile(src, dst); err != nil {
-			return fmt.Errorf("sync %s: %w", filepath.Base(src), err)
-		}
-	}
-	return nil
-}
-
-func (FileSyncer) SyncClaudeSettings(cfg Config) error {
-	src := filepath.Join(cfg.SourceDir, ".claude", "settings.local.json")
-	dst := filepath.Join(cfg.TargetDir, ".claude", "settings.local.json")
-	if err := copyFile(src, dst); err != nil {
-		return fmt.Errorf("sync .claude/settings.local.json: %w", err)
-	}
-	return nil
-}
-
-func (FileSyncer) SyncEnvFiles(cfg Config) error {
-	for _, name := range []string{".env", ".env.docker-compose"} {
-		src := filepath.Join(cfg.SourceDir, name)
-		dst := filepath.Join(cfg.TargetDir, name)
-		if err := copyFile(src, dst); err != nil {
-			return fmt.Errorf("sync %s: %w", name, err)
-		}
-	}
-	return nil
-}
-
-func SyncAll(syncer Syncer, source string, worktrees []worktree.Worktree) error {
-	srcAbs, err := filepath.Abs(source)
-	if err != nil {
-		return fmt.Errorf("resolve source path: %w", err)
-	}
-
-	for _, wt := range worktrees {
-		wtAbs, err := filepath.Abs(wt.Path)
+func (FileSyncer) Sync(patterns []string, cfg Config) error {
+	for _, pattern := range patterns {
+		matches, err := filepath.Glob(filepath.Join(cfg.SourceDir, pattern))
 		if err != nil {
-			return fmt.Errorf("resolve worktree path %s: %w", wt.Path, err)
+			return fmt.Errorf("invalid pattern %q: %w", pattern, err)
 		}
-		if wtAbs == srcAbs {
-			continue // source and target are the same directory
-		}
-
-		cfg := Config{SourceDir: srcAbs, TargetDir: wtAbs}
-		fmt.Printf("  syncing configs → %s (%s)\n", wt.Branch, wt.Path)
-
-		if err := syncer.SyncVSCode(cfg); err != nil {
-			return err
-		}
-		if err := syncer.SyncClaudeSettings(cfg); err != nil {
-			return err
-		}
-		if err := syncer.SyncEnvFiles(cfg); err != nil {
-			return err
+		for _, src := range matches {
+			rel, _ := filepath.Rel(cfg.SourceDir, src)
+			dst := filepath.Join(cfg.TargetDir, rel)
+			if err := copyFile(src, dst); err != nil {
+				return fmt.Errorf("sync %s: %w", rel, err)
+			}
 		}
 	}
 	return nil
 }
 
-// copyFile returns nil when src does not exist rather than an error.
 func copyFile(src, dst string) error {
 	in, err := os.Open(src)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil
-		}
 		return err
 	}
 	defer func() { _ = in.Close() }()

--- a/internal/vscode/adapter.go
+++ b/internal/vscode/adapter.go
@@ -8,6 +8,15 @@ import (
 	"treepad/internal/worktree"
 )
 
+// vscodeSyncPatterns are the editor-specific files propagated to every worktree.
+var vscodeSyncPatterns = []string{
+	".vscode/settings.json",
+	".vscode/tasks.json",
+	".vscode/launch.json",
+	".vscode/extensions.json",
+	".vscode/*.code-snippets",
+}
+
 func init() {
 	editor.Register("vscode", func() editor.Adapter { return &Adapter{} })
 }
@@ -29,9 +38,21 @@ func (a *Adapter) Configure(worktrees []worktree.Worktree, opts editor.Options) 
 		}
 	}
 
-	fmt.Println("\nsyncing configs to worktrees...")
+	fmt.Println("\nsyncing VS Code configs to worktrees...")
 	syncer := sync.FileSyncer{}
-	return sync.SyncAll(syncer, opts.SourceDir, worktrees)
+	for _, wt := range worktrees {
+		if wt.Path == opts.SourceDir {
+			continue
+		}
+		fmt.Printf("  → %s (%s)\n", wt.Branch, wt.Path)
+		if err := syncer.Sync(vscodeSyncPatterns, sync.Config{
+			SourceDir: opts.SourceDir,
+			TargetDir: wt.Path,
+		}); err != nil {
+			return fmt.Errorf("sync vscode configs to %s: %w", wt.Branch, err)
+		}
+	}
+	return nil
 }
 
 func resolveExtensions(dir string) ([]string, error) {


### PR DESCRIPTION
## Summary

- New `internal/config`: `Load(repoRoot)` reads `.treepad.json`; returns `DefaultSyncFiles` when file is absent. Explicit `sync.files` array in the config replaces defaults entirely.
- Rewrote `internal/sync`: single-method `Syncer` interface — `Sync(patterns []string, cfg Config) error`. `FileSyncer` resolves glob patterns via `filepath.Glob`, creates destination directories, and copies matched files. Missing source files are silently skipped (glob returns nil for no matches). Removed `SyncVSCode`, `SyncClaudeSettings`, `SyncEnvFiles`, and `SyncAll`.
- `internal/vscode/adapter.go`: owns its own sync loop using `vscodeSyncPatterns` (`.vscode/settings.json`, `tasks.json`, `launch.json`, `extensions.json`, `*.code-snippets`).
- `cmd/workspace`: loads config after adapter completes, appends `--include` flag values, runs a sync loop for tool-agnostic patterns (`.claude/`, `.env`).

## Why

The three-method sync interface encoded *what to sync* as Go methods. Adding a new sync target required a new interface method, a new implementation, and a release. The pattern-based approach makes sync targets data — configurable via `.treepad.json` or extended at runtime with `--include`.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] No `.treepad.json` → `DefaultSyncFiles` used
- [x] `.treepad.json` with `sync.files` → replaces defaults
- [x] `--include .tool-versions` → appended to patterns for the run
- [x] VS Code adapter syncs `.vscode/` files independently of tool-agnostic files

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)