### PR TITLE
feat: treepad remove <branch> — happy path (#18)

### DIFF
--- a/ideas/2026-04-14-ideate.md
+++ b/ideas/2026-04-14-ideate.md
@@ -1,0 +1,147 @@
+# Treepad Ideation — 2026-04-14
+
+## What is this?
+
+A Go CLI for managing git worktrees, purpose-built for parallel development workflows — particularly parallel Claude Code sessions. Three commands: `create` (worktree + config sync + workspace file), `workspace` (sync/generate workspace files), `config` (init/show).
+
+## Who is it for?
+
+Developers (yourself + small team) who run multiple AI coding sessions simultaneously and need isolated working directories that don't interfere with each other.
+
+## Implicit thesis
+
+The future of AI-assisted development involves parallel agents on parallel tasks. Git worktrees are the right isolation primitive. An editor-first toolchain (`.code-workspace` files, synced configs) is more durable than a terminal-first one for this audience.
+
+---
+
+## Competitive landscape
+
+| Tool | Angle | Strength | Weakness |
+|------|-------|----------|----------|
+| **Worktrunk** | Most popular AI-parallel CLI | Hooks, quality-of-life features | Not editor-aware, no .code-workspace |
+| **workmux** | tmux-first (Rust) | Create + cleanup + dashboard in one | Rust, terminal-only, no editor workspace |
+| **gwq** (Go) | Status dashboard + tmux sessions | Go, fuzzy finder | No config sync, no .code-workspace |
+| **wtp** | Branch tracking + hooks | Automated setup | No Claude/editor-specific angle |
+| **LazyWorktree** | TUI, auto tmux/zellij sessions | Keyboard-driven | No config propagation |
+
+**Treepad's distinctive position:** The only tool that generates `.code-workspace` files and syncs Claude Code config (`.claude/settings.local.json`) across worktrees. Most competitors are terminal-first. Treepad is editor-first. That's the lane to own.
+
+---
+
+## Eureka
+
+The market has converged on tmux session management as the coordination primitive for parallel AI dev (workmux, gwq, LazyWorktree all do this). But for developers using VS Code, Cursor, or Windsurf as their primary environment, **a `.code-workspace` file is a better primitive than a tmux window** — it carries extension config, folder layout, and settings. Treepad already has this. Instead of trying to replicate what workmux does with tmux sessions, treepad should deepen the editor-workspace angle and add just enough tmux glue to close the lifecycle loop. Don't race workmux on its own track.
+
+---
+
+## Premises confirmed
+
+1. Cleanup is the highest-value gap — user's stated pain point, underserved by current commands.
+2. "Done" means: I decide when, but one command does everything (remove worktree, kill tmux window, delete workspace file, prune branch).
+3. `.code-workspace` differentiation is real — user wasn't aware of competitors; treepad's editor-first angle is distinctive.
+4. tmux integration should close the lifecycle loop, not replace the editor-first posture.
+
+---
+
+## Desired outcome
+
+A developer should be able to spin up a worktree in one command and tear it down completely in one command — with editor workspace and tmux window handled automatically at both ends.
+
+---
+
+## Ideas
+
+### Adjacent — small extensions, low lift
+
+#### 1. `treepad remove` — one-command worktree teardown
+
+**What:** `treepad remove <branch>` removes the worktree, optionally deletes the local branch, removes the generated `.code-workspace` file, and optionally kills the matching tmux window.
+
+**Why treepad is uniquely positioned:** Already knows the workspace file naming convention (uses `slug` package) and the worktree path. The removal logic is a direct inversion of `create`. No other tool in this space handles `.code-workspace` cleanup.
+
+**Feasibility:** Extends existing `worktree.List()` + `slug` + `workspace` packages. Tmux kill is a one-liner (`exec.Command("tmux", "kill-window", "-t", branchSlug)`). Flags: `--keep-branch`, `--no-tmux`. ~2–3 days.
+
+---
+
+#### 2. `treepad list` — status view of all worktrees
+
+**What:** Table output: branch name, path, git status (clean / N changes), whether a `.code-workspace` file exists, whether a tmux window named after the branch exists.
+
+**Why treepad is uniquely positioned:** Already calls `worktree.List()` internally. The workspace file name is deterministic. Adding tmux and git-status columns gives signal no other command surfaces today — and makes `remove` and `prune` more useful.
+
+**Feasibility:** Extends `worktree.List()`. Git status via `git status --short`. Tmux window check via `tmux list-windows`. Table formatting with `tabwriter`. ~1–2 days.
+
+---
+
+### Expansion — new surface, medium lift
+
+#### 3. `treepad prune` — batch cleanup of merged branches
+
+**What:** Finds all worktrees whose branches are already merged into main (`git branch --merged main`), prints a summary, and with `--confirm` removes them all in one pass (worktree + branch + workspace file + tmux window).
+
+**Why treepad is uniquely positioned:** No competitor handles the full teardown stack (worktree + workspace file + tmux). `prune` is only compelling if cleanup is complete — and treepad is the only tool positioned to make it complete for the editor-first audience.
+
+**Feasibility:** Builds on `treepad remove` logic (idea 1 is a dependency). Merged branch detection is one `git` call. Dry-run output by default, `--confirm` to execute. ~1–2 days after `remove` exists.
+
+---
+
+#### 4. tmux session bootstrap in `treepad create`
+
+**What:** After creating a worktree and generating the workspace file, optionally create a named tmux window (`--tmux` flag or config opt-in) running in the new worktree directory. Opens the editor workspace and the tmux window in one command.
+
+**Why treepad is uniquely positioned:** `create` already does the full setup (worktree → sync → workspace). Adding tmux as a final step closes the "ready to work" loop without rebuilding what create already does. This is additive, not a rewrite.
+
+**Feasibility:** `tmux new-window -n <slug> -c <path>`. Guarded by `--tmux` flag (default off) or `"tmux": true` in `.treepad.json` config. No new dependencies. ~1 day.
+
+---
+
+#### 5. Shell integration: `treepad cd` / `treepad switch`
+
+**What:** A shell function (bash/zsh snippet output by `treepad shell-init`) that makes `treepad switch <branch>` change the current terminal's directory to the matching worktree and optionally switch to its tmux window.
+
+**Why treepad is uniquely positioned:** CLIs can't change the parent shell's directory natively — this requires a shell function wrapper, which treepad can generate and print. The fuzzy branch selection (matching partial names to worktree paths) is a direct use of the existing `worktree.List()` data.
+
+**Feasibility:** `treepad shell-init` prints a shell function users paste into `.zshrc`. The function evals `treepad switch-path <branch>` (new subcommand, prints the path). Similar pattern to `rbenv init`. ~2 days.
+
+---
+
+### Moonshot — significant investment, high upside
+
+#### 6. PR-aware auto-cleanup (`treepad watch` or `treepad done --pr`)
+
+**What:** `treepad done <branch>` checks GitHub (via `gh` CLI) whether the branch's PR is merged, and if so executes the full teardown. Optionally, `treepad watch` polls in the background and notifies when a branch is safe to clean.
+
+**Why treepad is uniquely positioned:** Treepad is already opinionated about the Claude Code parallel workflow. A "PR merged → clean up" command closes the full loop of that workflow — spin up, code, PR, done — in a way no terminal-first tool does for editor-based users.
+
+**Feasibility:** Requires `gh pr view --json state,mergedAt` for the branch. No new API keys needed if user has `gh` authenticated. The teardown is `remove` (idea 1). Medium lift: ~3–4 days. Dependency on idea 1.
+
+---
+
+#### 7. Interactive TUI: `treepad status`
+
+**What:** A bubbletea-powered interactive panel showing all worktrees as a list: branch, git status, workspace file present, tmux window live. Keyboard shortcuts: `d` to remove, `o` to open workspace, `t` to switch tmux window, `p` to prune merged.
+
+**Why treepad is uniquely positioned:** No competitor combines editor-workspace awareness with an interactive TUI. Most TUI tools (LazyWorktree) are terminal-only and don't know about `.code-workspace`. This would be the one-stop dashboard for the parallel AI dev workflow.
+
+**Feasibility:** Requires [bubbletea](https://github.com/charmbracelet/bubbletea) — new dependency. Significant UI work (~1–2 weeks). The data layer (list + status + workspace check) comes from ideas 1+2. Only makes sense after `remove` and `list` are solid foundations.
+
+---
+
+## Recommended next step
+
+**Build `treepad remove` first.**
+
+It directly solves the stated pain (cleanup is a one-command manual trigger), is the tracer bullet that unlocks everything else (`prune`, `watch`, TUI all depend on a solid remove), and it's the inversion of `create` — you already have all the building blocks.
+
+**Tracer-bullet first slice for `treepad remove`:**
+
+1. Add `internal/commands/remove.go` — new `remove` command wired into the CLI router
+2. Add `internal/workspace/remove.go` (or extend `Service`) — `RemoveWorktree(ctx, branch)` method: find the worktree by branch slug, call `git worktree remove`, delete the `.code-workspace` file by the same slug naming convention
+3. Wire `--keep-branch` flag (default: delete the local branch after worktree is gone)
+4. Add `--tmux` flag (default off): run `tmux kill-window -t <slug>` if the window exists
+
+Test-drive it with the existing fake `CommandRunner` pattern.
+
+**Then:** `treepad list` (2 days), `treepad prune` (1 day), tmux bootstrap in `create` (1 day). That's a complete lifecycle story in under a week.
+
+When ready to spec it formally: use `/write-a-prd`.

--- a/internal/commands/remove.go
+++ b/internal/commands/remove.go
@@ -1,0 +1,38 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/urfave/cli/v3"
+
+	internalsync "treepad/internal/sync"
+	"treepad/internal/workspace"
+	"treepad/internal/worktree"
+)
+
+func removeCommand() *cli.Command {
+	return &cli.Command{
+		Name:      "remove",
+		Usage:     "remove a git worktree and its associated files",
+		ArgsUsage: "<branch>",
+		Action:    runRemove,
+	}
+}
+
+func runRemove(ctx context.Context, cmd *cli.Command) error {
+	branch := cmd.Args().First()
+	if branch == "" {
+		return fmt.Errorf("branch name is required")
+	}
+
+	runner := worktree.ExecRunner{}
+	svc := workspace.NewService(
+		runner,
+		internalsync.FileSyncer{},
+		workspace.ExecOpener{Runner: runner},
+		os.Stdout,
+	)
+	return svc.Remove(ctx, workspace.RemoveInput{Branch: branch})
+}

--- a/internal/commands/router.go
+++ b/internal/commands/router.go
@@ -7,5 +7,6 @@ func Router() []*cli.Command {
 		workspaceCommand(),
 		configCommand(),
 		createCommand(),
+		removeCommand(),
 	}
 }

--- a/internal/workspace/service.go
+++ b/internal/workspace/service.go
@@ -42,6 +42,11 @@ type CreateInput struct {
 	OutputDir string
 }
 
+type RemoveInput struct {
+	Branch    string
+	OutputDir string
+}
+
 func (s *Service) Generate(ctx context.Context, in GenerateInput) error {
 	worktrees, err := s.listWorktrees(ctx)
 	if err != nil {
@@ -146,6 +151,53 @@ func (s *Service) Create(ctx context.Context, in CreateInput) error {
 			return fmt.Errorf("open workspace: %w", err)
 		}
 	}
+	return nil
+}
+
+func (s *Service) Remove(ctx context.Context, in RemoveInput) error {
+	worktrees, err := s.listWorktrees(ctx)
+	if err != nil {
+		return err
+	}
+
+	mainWT, err := worktree.MainWorktree(worktrees)
+	if err != nil {
+		return err
+	}
+
+	repoSlug := slug.Slug(filepath.Base(mainWT.Path))
+
+	var target *worktree.Worktree
+	for i := range worktrees {
+		if worktrees[i].Branch == in.Branch {
+			target = &worktrees[i]
+			break
+		}
+	}
+	if target == nil {
+		return fmt.Errorf("no worktree found for branch %q", in.Branch)
+	}
+
+	if _, err := s.runner.Run(ctx, "git", "worktree", "remove", target.Path); err != nil {
+		return fmt.Errorf("git worktree remove: %w", err)
+	}
+	_, _ = fmt.Fprintf(s.out, "removed worktree: %s\n", target.Path)
+
+	outputDir, err := s.resolveOutputDir(in.OutputDir, repoSlug)
+	if err != nil {
+		return err
+	}
+	wsPath := filepath.Join(outputDir, codeworkspace.Filename(repoSlug, in.Branch))
+	if err := os.Remove(wsPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove workspace file: %w", err)
+	}
+	_, _ = fmt.Fprintf(s.out, "removed workspace file: %s\n", wsPath)
+
+	if _, err := s.runner.Run(ctx, "git", "branch", "-d", in.Branch); err != nil {
+		return fmt.Errorf("git branch -d: %w", err)
+	}
+	_, _ = fmt.Fprintf(s.out, "deleted branch: %s\n", in.Branch)
+
 	return nil
 }
 

--- a/internal/workspace/service_test.go
+++ b/internal/workspace/service_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"treepad/internal/codeworkspace"
+	"treepad/internal/slug"
 	internalsync "treepad/internal/sync"
 	"treepad/internal/worktree"
 )
@@ -248,6 +250,111 @@ func TestServiceCreate(t *testing.T) {
 				Base:      "main",
 				OutputDir: outputDir,
 			})
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("got error %v, want error containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func twoWorktreePorcelainWithMain(mainPath, featPath string) []byte {
+	return fmt.Appendf(nil,
+		"worktree %s\nHEAD abc123\nbranch refs/heads/main\n\nworktree %s\nHEAD def456\nbranch refs/heads/feat\n\n",
+		mainPath, featPath,
+	)
+}
+
+func TestServiceRemove(t *testing.T) {
+	mainPath := t.TempDir()
+	if err := os.Mkdir(filepath.Join(mainPath, ".git"), 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	featPath := mainPath + "-feat"
+	outputDir := t.TempDir()
+	repoSlug := slug.Slug(filepath.Base(mainPath))
+	porcelain := twoWorktreePorcelainWithMain(mainPath, featPath)
+
+	t.Run("removes worktree, workspace file, and branch", func(t *testing.T) {
+		wsFile := filepath.Join(outputDir, codeworkspace.Filename(repoSlug, "feat"))
+		if err := os.WriteFile(wsFile, []byte("{}"), 0o644); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+
+		runner := &seqRunner{responses: []runResponse{
+			{output: porcelain}, // git worktree list
+			{},                  // git worktree remove
+			{},                  // git branch -d
+		}}
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard)
+
+		err := svc.Remove(context.Background(), RemoveInput{Branch: "feat", OutputDir: outputDir})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if _, err := os.Stat(wsFile); !os.IsNotExist(err) {
+			t.Error("workspace file should have been deleted")
+		}
+		if runner.idx != 3 {
+			t.Errorf("runner called %d times, want 3", runner.idx)
+		}
+	})
+
+	t.Run("workspace file missing is not an error", func(t *testing.T) {
+		runner := &seqRunner{responses: []runResponse{
+			{output: porcelain},
+			{},
+			{},
+		}}
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard)
+
+		err := svc.Remove(context.Background(), RemoveInput{Branch: "feat", OutputDir: outputDir})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	errorTests := []struct {
+		name    string
+		runner  *seqRunner
+		wantErr string
+	}{
+		{
+			name: "git worktree list fails",
+			runner: &seqRunner{responses: []runResponse{
+				{err: errors.New("git not found")},
+			}},
+			wantErr: "git not found",
+		},
+		{
+			name: "branch not found in worktree list",
+			runner: &seqRunner{responses: []runResponse{
+				{output: mainWorktreePorcelain(mainPath)},
+			}},
+			wantErr: `no worktree found for branch "feat"`,
+		},
+		{
+			name: "git worktree remove fails",
+			runner: &seqRunner{responses: []runResponse{
+				{output: porcelain},
+				{err: errors.New("locked worktree")},
+			}},
+			wantErr: "locked worktree",
+		},
+		{
+			name: "git branch -d fails",
+			runner: &seqRunner{responses: []runResponse{
+				{output: porcelain},
+				{},
+				{err: errors.New("branch not found")},
+			}},
+			wantErr: "branch not found",
+		},
+	}
+	for _, tt := range errorTests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := NewService(tt.runner, &fakeSyncer{}, &fakeOpener{}, io.Discard)
+			err := svc.Remove(context.Background(), RemoveInput{Branch: "feat", OutputDir: outputDir})
 			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 				t.Errorf("got error %v, want error containing %q", err, tt.wantErr)
 			}


### PR DESCRIPTION
## Summary

- Adds `treepad remove <branch>` command (end-to-end: CLI → `Service.Remove` → router)
- Removes the git worktree, deletes the `.code-workspace` file, and deletes the local branch (`git branch -d`) in one invocation
- Missing workspace file is a no-op
- Unknown branch returns a clear error

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes — `TestServiceRemove` covers happy path, missing workspace file, and all error cases

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)