### PR TITLE
feat: --force flag for dirty worktrees and unmerged branches (#20)

### DIFF
--- a/internal/commands/remove.go
+++ b/internal/commands/remove.go
@@ -17,7 +17,14 @@ func removeCommand() *cli.Command {
 		Name:      "remove",
 		Usage:     "remove a git worktree and its associated files",
 		ArgsUsage: "<branch>",
-		Action:    runRemove,
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:    "force",
+				Aliases: []string{"f"},
+				Usage:   "discard uncommitted changes and force-delete unmerged branch",
+			},
+		},
+		Action: runRemove,
 	}
 }
 
@@ -34,5 +41,8 @@ func runRemove(ctx context.Context, cmd *cli.Command) error {
 		workspace.ExecOpener{Runner: runner},
 		os.Stdout,
 	)
-	return svc.Remove(ctx, workspace.RemoveInput{Branch: branch})
+	return svc.Remove(ctx, workspace.RemoveInput{
+		Branch: branch,
+		Force:  cmd.Bool("force"),
+	})
 }

--- a/internal/workspace/service.go
+++ b/internal/workspace/service.go
@@ -45,6 +45,7 @@ type CreateInput struct {
 
 type RemoveInput struct {
 	Branch    string
+	Force     bool
 	OutputDir string
 	// Cwd overrides os.Getwd for testing the cwd-inside guard.
 	Cwd string
@@ -196,7 +197,11 @@ func (s *Service) Remove(ctx context.Context, in RemoveInput) error {
 		return fmt.Errorf("cannot remove the worktree you are currently in; cd elsewhere first")
 	}
 
-	if _, err := s.runner.Run(ctx, "git", "worktree", "remove", target.Path); err != nil {
+	wtRemoveArgs := []string{"worktree", "remove", target.Path}
+	if in.Force {
+		wtRemoveArgs = []string{"worktree", "remove", "--force", target.Path}
+	}
+	if _, err := s.runner.Run(ctx, "git", wtRemoveArgs...); err != nil {
 		return fmt.Errorf("git worktree remove: %w", err)
 	}
 	_, _ = fmt.Fprintf(s.out, "removed worktree: %s\n", target.Path)
@@ -211,8 +216,12 @@ func (s *Service) Remove(ctx context.Context, in RemoveInput) error {
 	}
 	_, _ = fmt.Fprintf(s.out, "removed workspace file: %s\n", wsPath)
 
-	if _, err := s.runner.Run(ctx, "git", "branch", "-d", in.Branch); err != nil {
-		return fmt.Errorf("git branch -d: %w", err)
+	branchFlag := "-d"
+	if in.Force {
+		branchFlag = "-D"
+	}
+	if _, err := s.runner.Run(ctx, "git", "branch", branchFlag, in.Branch); err != nil {
+		return fmt.Errorf("git branch %s: %w", branchFlag, err)
 	}
 	_, _ = fmt.Fprintf(s.out, "deleted branch: %s\n", in.Branch)
 

--- a/internal/workspace/service_test.go
+++ b/internal/workspace/service_test.go
@@ -57,6 +57,23 @@ func (s *seqRunner) Run(_ context.Context, _ string, _ ...string) ([]byte, error
 	return r.output, r.err
 }
 
+// recRunner records every call's args in order alongside its canned response.
+type recRunner struct {
+	responses []runResponse
+	calls     [][]string
+	idx       int
+}
+
+func (r *recRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	r.calls = append(r.calls, append([]string{name}, args...))
+	if r.idx >= len(r.responses) {
+		return nil, fmt.Errorf("unexpected runner call %d", r.idx)
+	}
+	resp := r.responses[r.idx]
+	r.idx++
+	return resp.output, resp.err
+}
+
 // fakeOpener records calls and returns a configured error.
 type fakeOpener struct {
 	calls []string
@@ -257,6 +274,15 @@ func TestServiceCreate(t *testing.T) {
 	}
 }
 
+func contains(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
 func twoWorktreePorcelainWithMain(mainPath, featPath string) []byte {
 	return fmt.Appendf(nil,
 		"worktree %s\nHEAD abc123\nbranch refs/heads/main\n\nworktree %s\nHEAD def456\nbranch refs/heads/feat\n\n",
@@ -297,6 +323,31 @@ func TestServiceRemove(t *testing.T) {
 		}
 		if runner.idx != 3 {
 			t.Errorf("runner called %d times, want 3", runner.idx)
+		}
+	})
+
+	t.Run("--force uses git worktree remove --force and git branch -D", func(t *testing.T) {
+		runner := &recRunner{responses: []runResponse{
+			{output: porcelain},
+			{}, // git worktree remove --force
+			{}, // git branch -D
+		}}
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard)
+
+		err := svc.Remove(context.Background(), RemoveInput{Branch: "feat", Force: true, OutputDir: outputDir})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(runner.calls) != 3 {
+			t.Fatalf("runner called %d times, want 3", len(runner.calls))
+		}
+		wtArgs := runner.calls[1]
+		if len(wtArgs) < 2 || wtArgs[1] != "worktree" || !contains(wtArgs, "--force") {
+			t.Errorf("expected 'git worktree remove --force ...', got %v", wtArgs)
+		}
+		branchArgs := runner.calls[2]
+		if len(branchArgs) < 2 || !contains(branchArgs, "-D") {
+			t.Errorf("expected 'git branch -D ...', got %v", branchArgs)
 		}
 	})
 


### PR DESCRIPTION
## Summary

- Adds `--force` / `-f` bool flag to `treepad remove`
- With `--force`: issues `git worktree remove --force` (discards uncommitted changes) and `git branch -D` (force-deletes unmerged branch)
- Without `--force`: keeps `git worktree remove` (clean only) and `git branch -d` (merge-aware)
- Added `recRunner` test helper that records exact call args; `--force` test asserts `--force` and `-D` are present in the correct calls

## Test plan

- [x] `--force` test verifies exact git args via `recRunner`
- [x] `go test ./...` passes

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)