### PR TITLE
feat: unmerged-clean branch warning path (#21)

### DIFF
--- a/internal/workspace/service.go
+++ b/internal/workspace/service.go
@@ -221,6 +221,10 @@ func (s *Service) Remove(ctx context.Context, in RemoveInput) error {
 		branchFlag = "-D"
 	}
 	if _, err := s.runner.Run(ctx, "git", "branch", branchFlag, in.Branch); err != nil {
+		if !in.Force && strings.Contains(err.Error(), "not fully merged") {
+			_, _ = fmt.Fprintf(s.out, "branch %s not merged; kept. Re-run with --force to delete, or run: git branch -d %s\n", in.Branch, in.Branch)
+			return nil
+		}
 		return fmt.Errorf("git branch %s: %w", branchFlag, err)
 	}
 	_, _ = fmt.Fprintf(s.out, "deleted branch: %s\n", in.Branch)

--- a/internal/workspace/service_test.go
+++ b/internal/workspace/service_test.go
@@ -351,6 +351,28 @@ func TestServiceRemove(t *testing.T) {
 		}
 	})
 
+	t.Run("unmerged branch without --force: worktree+workspace removed, branch kept, exit 0", func(t *testing.T) {
+		wsFile := filepath.Join(outputDir, codeworkspace.Filename(repoSlug, "feat"))
+		if err := os.WriteFile(wsFile, []byte("{}"), 0o644); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+
+		runner := &seqRunner{responses: []runResponse{
+			{output: porcelain},
+			{}, // git worktree remove
+			{err: errors.New("error: The branch 'feat' is not fully merged.")},
+		}}
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard)
+
+		err := svc.Remove(context.Background(), RemoveInput{Branch: "feat", OutputDir: outputDir})
+		if err != nil {
+			t.Fatalf("expected nil error on unmerged-clean path, got: %v", err)
+		}
+		if _, err := os.Stat(wsFile); !os.IsNotExist(err) {
+			t.Error("workspace file should have been deleted")
+		}
+	})
+
 	t.Run("workspace file missing is not an error", func(t *testing.T) {
 		runner := &seqRunner{responses: []runResponse{
 			{output: porcelain},


### PR DESCRIPTION
## Summary

- When `git branch -d` returns "not fully merged" and `--force` is absent: worktree and workspace file are still removed; branch is kept; a human-readable warning is printed; exit 0
- With `--force`, the error propagates normally through the `-D` path and removes the branch regardless

## Test plan

- [x] Test asserts `nil` error, workspace file deleted, worktree removed when unmerged error returned from fake runner
- [x] `go test ./...` passes

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)