### PR TITLE
feat: best-effort partial-failure + recovery mode (#22)

### DIFF
--- a/internal/commands/remove.go
+++ b/internal/commands/remove.go
@@ -34,5 +34,6 @@ func runRemove(ctx context.Context, cmd *cli.Command) error {
 		workspace.ExecOpener{Runner: runner},
 		os.Stdout,
 	)
-	return svc.Remove(ctx, workspace.RemoveInput{Branch: branch})
+	_, err := svc.Remove(ctx, workspace.RemoveInput{Branch: branch})
+	return err
 }

--- a/internal/workspace/service.go
+++ b/internal/workspace/service.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -48,6 +49,21 @@ type RemoveInput struct {
 	OutputDir string
 	// Cwd overrides os.Getwd for testing the cwd-inside guard.
 	Cwd string
+}
+
+// RemoveResult captures the per-step outcome of a Remove call.
+type RemoveResult struct {
+	WorktreeRemoved  bool
+	WorktreeErr      error
+	WorkspaceRemoved bool
+	WorkspaceErr     error
+	BranchDeleted    bool
+	BranchWarning    string // non-empty when branch is unmerged and kept (not an error)
+	BranchErr        error
+}
+
+func (r RemoveResult) Err() error {
+	return errors.Join(r.WorktreeErr, r.WorkspaceErr, r.BranchErr)
 }
 
 func (s *Service) Generate(ctx context.Context, in GenerateInput) error {
@@ -157,21 +173,23 @@ func (s *Service) Create(ctx context.Context, in CreateInput) error {
 	return nil
 }
 
-func (s *Service) Remove(ctx context.Context, in RemoveInput) error {
+func (s *Service) Remove(ctx context.Context, in RemoveInput) (RemoveResult, error) {
+	var result RemoveResult
+
 	worktrees, err := s.listWorktrees(ctx)
 	if err != nil {
-		return err
+		return result, err
 	}
 
 	mainWT, err := worktree.MainWorktree(worktrees)
 	if err != nil {
-		return err
+		return result, err
 	}
 
 	repoSlug := slug.Slug(filepath.Base(mainWT.Path))
 
 	if in.Branch == mainWT.Branch {
-		return fmt.Errorf("cannot remove the main worktree")
+		return result, fmt.Errorf("cannot remove the main worktree")
 	}
 
 	var target *worktree.Worktree
@@ -181,42 +199,72 @@ func (s *Service) Remove(ctx context.Context, in RemoveInput) error {
 			break
 		}
 	}
+
+	recoveryMode := false
 	if target == nil {
-		return fmt.Errorf("no worktree found for branch %q", in.Branch)
+		// Check for recovery mode: worktree is already gone but branch still exists.
+		out, listErr := s.runner.Run(ctx, "git", "branch", "--list", in.Branch)
+		if listErr != nil || strings.TrimSpace(string(out)) == "" {
+			return result, fmt.Errorf("no worktree found for branch %q", in.Branch)
+		}
+		recoveryMode = true
 	}
 
-	cwd := in.Cwd
-	if cwd == "" {
-		cwd, err = os.Getwd()
-		if err != nil {
-			return fmt.Errorf("get current directory: %w", err)
+	if !recoveryMode {
+		cwd := in.Cwd
+		if cwd == "" {
+			cwd, err = os.Getwd()
+			if err != nil {
+				return result, fmt.Errorf("get current directory: %w", err)
+			}
+		}
+		if rel, relErr := filepath.Rel(target.Path, cwd); relErr == nil && !strings.HasPrefix(rel, "..") {
+			return result, fmt.Errorf("cannot remove the worktree you are currently in; cd elsewhere first")
 		}
 	}
-	if rel, relErr := filepath.Rel(target.Path, cwd); relErr == nil && !strings.HasPrefix(rel, "..") {
-		return fmt.Errorf("cannot remove the worktree you are currently in; cd elsewhere first")
+
+	// Step 1: Remove worktree (skip in recovery mode).
+	if !recoveryMode {
+		if _, err := s.runner.Run(ctx, "git", "worktree", "remove", target.Path); err != nil {
+			result.WorktreeErr = fmt.Errorf("git worktree remove: %w", err)
+			_, _ = fmt.Fprintf(s.out, "failed to remove worktree %s: %v\n", target.Path, err)
+		} else {
+			result.WorktreeRemoved = true
+			_, _ = fmt.Fprintf(s.out, "removed worktree: %s\n", target.Path)
+		}
 	}
 
-	if _, err := s.runner.Run(ctx, "git", "worktree", "remove", target.Path); err != nil {
-		return fmt.Errorf("git worktree remove: %w", err)
+	// Step 2: Remove workspace file.
+	outputDir, resolveErr := s.resolveOutputDir(in.OutputDir, repoSlug)
+	if resolveErr != nil {
+		result.WorkspaceErr = resolveErr
+		_, _ = fmt.Fprintf(s.out, "failed to resolve workspace directory: %v\n", resolveErr)
+	} else {
+		wsPath := filepath.Join(outputDir, codeworkspace.Filename(repoSlug, in.Branch))
+		if err := os.Remove(wsPath); err != nil && !os.IsNotExist(err) {
+			result.WorkspaceErr = fmt.Errorf("remove workspace file: %w", err)
+			_, _ = fmt.Fprintf(s.out, "failed to remove workspace file %s: %v\n", wsPath, err)
+		} else {
+			result.WorkspaceRemoved = true
+			_, _ = fmt.Fprintf(s.out, "removed workspace file: %s\n", wsPath)
+		}
 	}
-	_, _ = fmt.Fprintf(s.out, "removed worktree: %s\n", target.Path)
 
-	outputDir, err := s.resolveOutputDir(in.OutputDir, repoSlug)
-	if err != nil {
-		return err
-	}
-	wsPath := filepath.Join(outputDir, codeworkspace.Filename(repoSlug, in.Branch))
-	if err := os.Remove(wsPath); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("remove workspace file: %w", err)
-	}
-	_, _ = fmt.Fprintf(s.out, "removed workspace file: %s\n", wsPath)
-
+	// Step 3: Delete local branch.
 	if _, err := s.runner.Run(ctx, "git", "branch", "-d", in.Branch); err != nil {
-		return fmt.Errorf("git branch -d: %w", err)
+		if strings.Contains(err.Error(), "not fully merged") {
+			result.BranchWarning = fmt.Sprintf("branch %s not merged; kept. Re-run with --force to delete, or run: git branch -d %s", in.Branch, in.Branch)
+			_, _ = fmt.Fprintf(s.out, "%s\n", result.BranchWarning)
+		} else {
+			result.BranchErr = fmt.Errorf("git branch -d: %w", err)
+			_, _ = fmt.Fprintf(s.out, "failed to delete branch %s: %v\n", in.Branch, err)
+		}
+	} else {
+		result.BranchDeleted = true
+		_, _ = fmt.Fprintf(s.out, "deleted branch: %s\n", in.Branch)
 	}
-	_, _ = fmt.Fprintf(s.out, "deleted branch: %s\n", in.Branch)
 
-	return nil
+	return result, result.Err()
 }
 
 type syncTarget struct {

--- a/internal/workspace/service_test.go
+++ b/internal/workspace/service_test.go
@@ -320,7 +320,7 @@ func TestServiceRemove(t *testing.T) {
 		runner := &seqRunner{responses: []runResponse{
 			{output: porcelain},
 			{err: errors.New("locked worktree")}, // git worktree remove fails
-			{},                                    // git branch -d still runs
+			{},                                   // git branch -d still runs
 		}}
 		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard)
 
@@ -341,9 +341,9 @@ func TestServiceRemove(t *testing.T) {
 
 	t.Run("recovery mode: no worktree but branch exists, cleans up branch", func(t *testing.T) {
 		runner := &seqRunner{responses: []runResponse{
-			{output: mainWorktreePorcelain(mainPath)},      // git worktree list: feat absent
-			{output: []byte("  feat\n")},                  // git branch --list feat: exists
-			{},                                             // git branch -d feat
+			{output: mainWorktreePorcelain(mainPath)}, // git worktree list: feat absent
+			{output: []byte("  feat\n")},              // git branch --list feat: exists
+			{},                                        // git branch -d feat
 		}}
 		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard)
 

--- a/internal/workspace/service_test.go
+++ b/internal/workspace/service_test.go
@@ -287,11 +287,13 @@ func TestServiceRemove(t *testing.T) {
 		}}
 		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard)
 
-		err := svc.Remove(context.Background(), RemoveInput{Branch: "feat", OutputDir: outputDir})
+		result, err := svc.Remove(context.Background(), RemoveInput{Branch: "feat", OutputDir: outputDir})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-
+		if !result.WorktreeRemoved || !result.WorkspaceRemoved || !result.BranchDeleted {
+			t.Errorf("expected all steps successful, got %+v", result)
+		}
 		if _, err := os.Stat(wsFile); !os.IsNotExist(err) {
 			t.Error("workspace file should have been deleted")
 		}
@@ -308,9 +310,55 @@ func TestServiceRemove(t *testing.T) {
 		}}
 		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard)
 
-		err := svc.Remove(context.Background(), RemoveInput{Branch: "feat", OutputDir: outputDir})
+		_, err := svc.Remove(context.Background(), RemoveInput{Branch: "feat", OutputDir: outputDir})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("best-effort: worktree remove fails but branch still deleted", func(t *testing.T) {
+		runner := &seqRunner{responses: []runResponse{
+			{output: porcelain},
+			{err: errors.New("locked worktree")}, // git worktree remove fails
+			{},                                    // git branch -d still runs
+		}}
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard)
+
+		result, err := svc.Remove(context.Background(), RemoveInput{Branch: "feat", OutputDir: outputDir})
+		if err == nil || !strings.Contains(err.Error(), "locked worktree") {
+			t.Errorf("expected error containing 'locked worktree', got %v", err)
+		}
+		if result.WorktreeErr == nil {
+			t.Error("expected WorktreeErr to be set")
+		}
+		if !result.BranchDeleted {
+			t.Error("expected branch deleted despite worktree failure")
+		}
+		if runner.idx != 3 {
+			t.Errorf("runner called %d times, want 3 (all steps attempted)", runner.idx)
+		}
+	})
+
+	t.Run("recovery mode: no worktree but branch exists, cleans up branch", func(t *testing.T) {
+		runner := &seqRunner{responses: []runResponse{
+			{output: mainWorktreePorcelain(mainPath)},      // git worktree list: feat absent
+			{output: []byte("  feat\n")},                  // git branch --list feat: exists
+			{},                                             // git branch -d feat
+		}}
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard)
+
+		result, err := svc.Remove(context.Background(), RemoveInput{Branch: "feat", OutputDir: outputDir})
+		if err != nil {
+			t.Fatalf("unexpected error in recovery mode: %v", err)
+		}
+		if result.WorktreeRemoved {
+			t.Error("worktree should not be removed in recovery mode")
+		}
+		if !result.BranchDeleted {
+			t.Error("expected branch deleted in recovery mode")
+		}
+		if runner.idx != 3 {
+			t.Errorf("runner called %d times, want 3", runner.idx)
 		}
 	})
 
@@ -329,29 +377,21 @@ func TestServiceRemove(t *testing.T) {
 			wantErr: "git not found",
 		},
 		{
-			name:   "branch not found in worktree list",
+			name:   "branch not found in worktree list and no local branch",
 			branch: "feat",
 			runner: &seqRunner{responses: []runResponse{
-				{output: mainWorktreePorcelain(mainPath)},
+				{output: mainWorktreePorcelain(mainPath)}, // worktree list: no feat
+				{output: []byte("")},                      // git branch --list feat: empty
 			}},
 			wantErr: `no worktree found for branch "feat"`,
 		},
 		{
-			name:   "git worktree remove fails",
-			branch: "feat",
-			runner: &seqRunner{responses: []runResponse{
-				{output: porcelain},
-				{err: errors.New("locked worktree")},
-			}},
-			wantErr: "locked worktree",
-		},
-		{
-			name:   "git branch -d fails",
+			name:   "git branch -d fails with real error",
 			branch: "feat",
 			runner: &seqRunner{responses: []runResponse{
 				{output: porcelain},
 				{},
-				{err: errors.New("branch not found")},
+				{err: errors.New("fatal: branch not found")},
 			}},
 			wantErr: "branch not found",
 		},
@@ -367,7 +407,7 @@ func TestServiceRemove(t *testing.T) {
 	for _, tt := range errorTests {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := NewService(tt.runner, &fakeSyncer{}, &fakeOpener{}, io.Discard)
-			err := svc.Remove(context.Background(), RemoveInput{Branch: tt.branch, OutputDir: outputDir})
+			_, err := svc.Remove(context.Background(), RemoveInput{Branch: tt.branch, OutputDir: outputDir})
 			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 				t.Errorf("got error %v, want error containing %q", err, tt.wantErr)
 			}
@@ -380,7 +420,7 @@ func TestServiceRemove(t *testing.T) {
 		}}
 		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard)
 
-		err := svc.Remove(context.Background(), RemoveInput{
+		_, err := svc.Remove(context.Background(), RemoveInput{
 			Branch:    "feat",
 			OutputDir: outputDir,
 			Cwd:       featPath,


### PR DESCRIPTION
## Summary

- Introduces `RemoveResult` struct with per-step status (`WorktreeRemoved`, `WorkspaceRemoved`, `BranchDeleted`, `BranchWarning`, and `*Err` fields per step)
- Changes `Service.Remove` to `(RemoveResult, error)` — best-effort execution: all three steps run regardless of individual step failure; aggregated error via `errors.Join`
- Recovery mode: when no worktree matches the branch but `git branch --list <branch>` returns output, skip the worktree removal step and proceed with workspace file + branch cleanup. Re-running after any partial failure is always safe.
- Unmerged-without-force sets `BranchWarning` and returns `nil` error (exit 0)

## Test plan

- [x] Best-effort test: worktree remove fails, branch delete still runs, `WorktreeErr` set, `BranchDeleted` true, exit non-zero
- [x] Recovery mode test: `WorktreeRemoved=false`, `BranchDeleted=true`, exit 0
- [x] "Branch not found + no local branch" still errors
- [x] `go test ./...` passes

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)