### PR TITLE
feat: pre-flight safety guards for treepad remove (#19)

### DIFF
--- a/internal/workspace/service.go
+++ b/internal/workspace/service.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"treepad/internal/codeworkspace"
 	"treepad/internal/config"
@@ -45,6 +46,8 @@ type CreateInput struct {
 type RemoveInput struct {
 	Branch    string
 	OutputDir string
+	// Cwd overrides os.Getwd for testing the cwd-inside guard.
+	Cwd string
 }
 
 func (s *Service) Generate(ctx context.Context, in GenerateInput) error {
@@ -167,6 +170,10 @@ func (s *Service) Remove(ctx context.Context, in RemoveInput) error {
 
 	repoSlug := slug.Slug(filepath.Base(mainWT.Path))
 
+	if in.Branch == mainWT.Branch {
+		return fmt.Errorf("cannot remove the main worktree")
+	}
+
 	var target *worktree.Worktree
 	for i := range worktrees {
 		if worktrees[i].Branch == in.Branch {
@@ -176,6 +183,17 @@ func (s *Service) Remove(ctx context.Context, in RemoveInput) error {
 	}
 	if target == nil {
 		return fmt.Errorf("no worktree found for branch %q", in.Branch)
+	}
+
+	cwd := in.Cwd
+	if cwd == "" {
+		cwd, err = os.Getwd()
+		if err != nil {
+			return fmt.Errorf("get current directory: %w", err)
+		}
+	}
+	if rel, relErr := filepath.Rel(target.Path, cwd); relErr == nil && !strings.HasPrefix(rel, "..") {
+		return fmt.Errorf("cannot remove the worktree you are currently in; cd elsewhere first")
 	}
 
 	if _, err := s.runner.Run(ctx, "git", "worktree", "remove", target.Path); err != nil {

--- a/internal/workspace/service_test.go
+++ b/internal/workspace/service_test.go
@@ -317,24 +317,28 @@ func TestServiceRemove(t *testing.T) {
 	errorTests := []struct {
 		name    string
 		runner  *seqRunner
+		branch  string
 		wantErr string
 	}{
 		{
-			name: "git worktree list fails",
+			name:   "git worktree list fails",
+			branch: "feat",
 			runner: &seqRunner{responses: []runResponse{
 				{err: errors.New("git not found")},
 			}},
 			wantErr: "git not found",
 		},
 		{
-			name: "branch not found in worktree list",
+			name:   "branch not found in worktree list",
+			branch: "feat",
 			runner: &seqRunner{responses: []runResponse{
 				{output: mainWorktreePorcelain(mainPath)},
 			}},
 			wantErr: `no worktree found for branch "feat"`,
 		},
 		{
-			name: "git worktree remove fails",
+			name:   "git worktree remove fails",
+			branch: "feat",
 			runner: &seqRunner{responses: []runResponse{
 				{output: porcelain},
 				{err: errors.New("locked worktree")},
@@ -342,7 +346,8 @@ func TestServiceRemove(t *testing.T) {
 			wantErr: "locked worktree",
 		},
 		{
-			name: "git branch -d fails",
+			name:   "git branch -d fails",
+			branch: "feat",
 			runner: &seqRunner{responses: []runResponse{
 				{output: porcelain},
 				{},
@@ -350,16 +355,43 @@ func TestServiceRemove(t *testing.T) {
 			}},
 			wantErr: "branch not found",
 		},
+		{
+			name:   "refuses to remove main worktree",
+			branch: "main",
+			runner: &seqRunner{responses: []runResponse{
+				{output: mainWorktreePorcelain(mainPath)},
+			}},
+			wantErr: "main worktree",
+		},
 	}
 	for _, tt := range errorTests {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := NewService(tt.runner, &fakeSyncer{}, &fakeOpener{}, io.Discard)
-			err := svc.Remove(context.Background(), RemoveInput{Branch: "feat", OutputDir: outputDir})
+			err := svc.Remove(context.Background(), RemoveInput{Branch: tt.branch, OutputDir: outputDir})
 			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 				t.Errorf("got error %v, want error containing %q", err, tt.wantErr)
 			}
 		})
 	}
+
+	t.Run("refuses to remove worktree user is currently in", func(t *testing.T) {
+		runner := &seqRunner{responses: []runResponse{
+			{output: porcelain},
+		}}
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard)
+
+		err := svc.Remove(context.Background(), RemoveInput{
+			Branch:    "feat",
+			OutputDir: outputDir,
+			Cwd:       featPath,
+		})
+		if err == nil || !strings.Contains(err.Error(), "currently in") {
+			t.Errorf("got error %v, want error containing %q", err, "currently in")
+		}
+		if runner.idx != 1 {
+			t.Errorf("runner called %d times after guard, want 1 (list only)", runner.idx)
+		}
+	})
 }
 
 func TestResolveSourceDir(t *testing.T) {


### PR DESCRIPTION
## Summary

Pre-flight guards missed main in the merge sequence — this brings them in.

- Refuses to remove the main worktree
- Refuses to remove the worktree the user is currently in
- Both guards fire before any destructive git call

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)