### PR TITLE
docs: document treepad remove command

### DIFF
--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -35,6 +35,14 @@ Central location for all CLI command definitions. Separates CLI wiring from busi
   - Instantiates `workspace.Service` and calls `Create()`
   - Creates instances of `worktree.ExecRunner`, `sync.FileSyncer`, `workspace.ExecOpener`
 
+### `remove.go`
+
+- `removeCommand()` — top-level remove command definition
+- `runRemove(ctx, cmd)` — action handler for removing worktrees
+  - Parses branch argument (required)
+  - Instantiates `workspace.Service` and calls `Remove()`
+  - Creates instances of `worktree.ExecRunner`, `sync.FileSyncer`
+
 ### `config.go`
 
 - `configCommand()` — top-level config command group
@@ -88,6 +96,10 @@ Pure business logic for worktree syncing and workspace file generation.
     - Resolves config source, loads config, syncs files, generates workspace files
   - `Create(ctx, CreateInput)` — creates new worktree, syncs configs, generates workspace file
     - Input: `Branch`, `Base`, `Open`, `OutputDir`
+  - `Remove(ctx, RemoveInput)` — removes worktree, workspace file, and branch
+    - Input: `Branch`, `OutputDir`, `Cwd` (for testing)
+    - Pre-flight guards: prevents removing main worktree, prevents removing from within the target worktree
+    - Three-step removal: git worktree remove → delete workspace file → git branch -d
 - Private helpers:
   - `listWorktrees(ctx)` — lists all worktrees in repo
   - `resolveOutputDir(explicit, repoSlug)` — resolves workspace output directory
@@ -154,6 +166,7 @@ treepad [--verbose] <command>
 ├── create [options] <branch>
 │   ├── --base (default: main)
 │   └── --open (-o)
+├── remove <branch>
 └── config
     ├── init [--global]
     └── show
@@ -206,6 +219,18 @@ treepad [--verbose] <command>
 4. Calls `config.Show(mainPath)`
 5. `Show()` checks local, global, and defaults; returns formatted summary with sources
 
+## Data Flow Example: `treepad remove <branch>`
+
+1. `main.go` parses flags and calls `commands.Router()`
+2. `commands.removeCommand()` defines CLI interface
+3. `runRemove()` parses branch argument, instantiates `workspace.Service`, calls `Remove()`
+4. `Service.Remove()` executes three steps:
+   - Lists all worktrees, validates branch exists and is not main
+   - Pre-flight guard: ensures cwd is not inside the target worktree
+   - Removes git worktree via `git worktree remove`
+   - Deletes `.code-workspace` file from output directory (missing file is not an error)
+   - Deletes branch locally via `git branch -d`
+
 ---
 
-**Last Updated:** April 13, 2026 (refactored workspace package: unified Orchestrator/Creator into Service)
+**Last Updated:** April 15, 2026 (added `treepad remove` command documentation)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,27 @@ treepad workspace --include ".prettierrc" --include ".eslintrc.json"
 treepad --verbose workspace
 ```
 
+**`create`** — Create a new git worktree with configs synced and workspace file generated:
+
+```bash
+# Create a new worktree for branch 'feature-x' branched from main
+treepad create feature-x
+
+# Create a worktree from a different base ref
+treepad create bugfix-y --base develop
+
+# Create a worktree and open the workspace file
+treepad create feature-z --open
+```
+
+**`remove`** — Remove a git worktree and its associated files:
+
+```bash
+# Remove a completed feature branch (switch out of it first)
+cd ../main-repo
+treepad remove feature-x
+```
+
 **`config`** — Manage treepad configuration:
 
 ```bash

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -155,3 +155,38 @@ Config:
 ```
 
 See [configuration.md](configuration.md) for details on the configuration schema and defaults.
+
+## remove
+
+Remove a git worktree, delete its `.code-workspace` file, and delete the local branch.
+
+```
+treepad remove <branch>
+```
+
+Removes the worktree for the specified branch, cleans up its associated `.code-workspace` file, and deletes the branch locally. Includes pre-flight safety guards to prevent accidental data loss.
+
+### Pre-flight guards
+
+- Refuses to remove the main worktree
+- Refuses to remove a worktree if you are currently inside it (must `cd` elsewhere first)
+
+### Examples
+
+```bash
+# Remove a completed feature branch
+treepad remove feature-x
+
+# Remove after switching out of the worktree
+cd ../main-repo  # or any other location
+treepad remove feature-x
+```
+
+### Errors
+
+Attempting to remove the main worktree or the worktree you're currently in will return an error:
+
+```
+cannot remove the main worktree
+cannot remove the worktree you are currently in; cd elsewhere first
+```


### PR DESCRIPTION
## Summary

- `README.md` — adds `treepad remove` to the commands overview
- `docs/commands.md` — full reference for `remove`: flags, pre-flight guards, branch deletion behaviour, examples
- `CODEMAP.md` — adds `remove.go`, documents `Service.Remove` three-step flow, updates CLI command tree and data-flow diagram

🤖 Generated with [Claude Code](https://claude.com/claude-code)