### PR TITLE
feat: treepad status — repo-wide worktree snapshot

### DIFF
--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -62,6 +62,14 @@ Central location for all CLI command definitions. Separates CLI wiring from busi
   - Resolves worktrees and main worktree path
   - Calls `config.Show(repoRoot)` to display resolved config and sources
 
+### `status.go`
+
+- `statusCommand()` — top-level status command definition
+- `runStatus(ctx, cmd)` — action handler for listing worktree status
+  - Parses flag: `--json` (emit JSON instead of table)
+  - Instantiates `treepad.Service` and calls `Status()`
+  - Creates instances of `worktree.ExecRunner`, `sync.FileSyncer`, `artifact.ExecOpener`
+
 ## Config Package (`internal/config/`)
 
 Handles TOML configuration file loading, initialization, and display.
@@ -120,6 +128,10 @@ Pure business logic for worktree syncing and artifact file generation. Formerly 
     - Finds merged branches, filters out main/detached/current worktree
     - Executes removals by default; `DryRun: true` previews without removing
     - Returns error if any removals fail (after attempting all)
+  - `Status(ctx, StatusInput)` — lists all worktrees with repo-wide status snapshot
+    - Input: `JSON` (emit JSON instead of table), `OutputDir` (for artifact path resolution)
+    - Output: builds `[]StatusRow` with branch, dirty state, ahead/behind count, last commit info, artifact mtime
+    - Renders as aligned table via `text/tabwriter` by default, or JSON array with `--json` flag
 - Private helpers:
   - `removeWorktree(ctx, target, mainWT, outputDir)` — removes a single worktree, deletes artifact, deletes branch
   - `listWorktrees(ctx)` — lists all worktrees in repo
@@ -142,12 +154,22 @@ Wrapper around git worktree operations.
 ### `worktree.go`
 
 - `Worktree` struct — represents a single git worktree with Path, Branch, etc.
+- `CommitInfo` struct — summary of a git commit: `ShortSHA`, `Subject`, `Committed` (time.Time)
 - `ExecRunner` — executes `git` commands (dependency injection)
 - `List(ctx, runner)` — lists all worktrees in a repo
 - `MainWorktree(worktrees)` — returns the main worktree (contains `.git` directory)
 - `MergedBranches(ctx, runner, base string)` — returns local branches merged into base (excluding base itself)
   - Runs `git branch --merged <base> --format=%(refname:short)`
   - Returns string slice of branch names
+- `Dirty(ctx, runner, path)` — reports whether worktree at path has uncommitted changes
+  - Runs `git -C <path> status --porcelain`
+- `AheadBehind(ctx, runner, path)` — counts commits ahead/behind upstream
+  - First checks if upstream exists via `git rev-parse --abbrev-ref @{upstream}`
+  - Returns `(ahead, behind, hasUpstream=false, nil)` if no upstream configured (not an error)
+  - If upstream exists, runs `git rev-list --left-right --count HEAD...@{upstream}`
+- `LastCommit(ctx, runner, path)` — returns info about HEAD commit
+  - Runs `git log -1 --format=%h%x00%s%x00%cI`
+  - Returns empty `CommitInfo{}` if no commits; error on timestamp parse failure
 
 ## Sync Package (`internal/sync/`)
 
@@ -205,6 +227,8 @@ treepad [--verbose] <command>
 ├── prune [options]
 │   ├── --base (default: main)
 │   └── --dry-run
+├── status [options]
+│   └── --json
 └── config
     ├── init [--global]
     └── show
@@ -284,6 +308,22 @@ treepad [--verbose] <command>
    - Otherwise removes each candidate via `removeWorktree()`
    - Returns error if any removals failed
 
+## Data Flow Example: `treepad status [--json]`
+
+1. `main.go` parses flags and calls `commands.Router()`
+2. `commands.statusCommand()` defines CLI interface
+3. `runStatus()` parses flags, instantiates `treepad.Service`, calls `Status()`
+4. `Service.Status()` executes:
+   - Lists all worktrees via `worktree.List()`
+   - For each worktree, probes:
+     - `worktree.Dirty()` — checks `git status --porcelain`
+     - `worktree.AheadBehind()` — compares vs `@{upstream}` if configured
+     - `worktree.LastCommit()` — fetches HEAD commit info
+   - Computes artifact file path via `artifact.Path()` and checks mtime
+   - Builds `[]StatusRow` with all collected info
+   - If `--json` flag set, encodes as JSON array; otherwise renders via `text/tabwriter` table
+   - Writes to `s.out` and returns
+
 ---
 
-**Last Updated:** April 15, 2026 (prune executes by default; `--dry-run` previews)
+**Last Updated:** April 15, 2026 (added `status` command for repo-wide worktree status snapshot)

--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ treepad prune --dry-run
 treepad prune --base develop
 ```
 
+**`status`** — List all worktrees with their branch, dirty state, ahead/behind count, and last commit:
+
+```bash
+# Show status of all worktrees in a table
+treepad status
+
+# Emit JSON for scripting or dashboards
+treepad status --json
+```
+
 **`config`** — Manage treepad configuration:
 
 ```bash

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -265,3 +265,78 @@ removed worktree: /path/to/repo/repo-feature-y
 removed artifact: /home/user/repo-workspaces/repo-feature-y.code-workspace
 deleted branch: feature-y
 ```
+
+## status
+
+List all worktrees in the repo with their branch, dirty state, ahead/behind count vs upstream, last commit, and last-touched time (from artifact file mtime).
+
+```
+treepad status [options]
+```
+
+Provides a repo-wide snapshot of all active worktrees, showing which ones have uncommitted changes, how they diverge from their upstream branches, and when they were last modified by agents or editors.
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Emit JSON array instead of an aligned table |
+
+### Output Columns (Table Format)
+
+| Column | Meaning |
+|--------|---------|
+| `BRANCH` | Branch name, with `*` suffix if main worktree |
+| `STATUS` | `clean` or `dirty` (has uncommitted changes) |
+| `AHEAD/BEHIND` | `↑N ↓M` vs upstream, or `—` if no upstream configured |
+| `LAST COMMIT` | Short SHA, subject, and relative time (e.g. `abc1234 fix thing · 3m`) |
+| `TOUCHED` | Relative time since artifact file was last modified, or `—` if no artifact |
+| `PATH` | Absolute path (collapsed to `~/...` when under home directory) |
+
+### Examples
+
+```bash
+# Show status of all worktrees in a table
+treepad status
+
+# Emit JSON for scripting or dashboards
+treepad status --json
+
+# Combine with standard tools
+treepad status | grep dirty
+treepad status --json | jq '.[] | select(.dirty == true)'
+```
+
+### Output Examples
+
+**Table output:**
+
+```
+BRANCH                   STATUS  AHEAD/BEHIND  LAST COMMIT                            TOUCHED  PATH
+main *                   dirty   ↑0 ↓0         ea69222 Merge PR #33 · 1h             1d       ~/treepad
+feat/status              clean   —             ea69222 Merge PR #33 · 1h             18m      ~/treepad-feat-status
+task/remove-guards       clean   ↑0 ↓6         8305b88 add pre-flight guards · 6h    —        ~/treepad-remove-guards
+```
+
+**JSON output (pretty-printed):**
+
+```json
+[
+  {
+    "branch": "main",
+    "path": "/Users/user/treepad",
+    "is_main": true,
+    "dirty": true,
+    "ahead": 0,
+    "behind": 0,
+    "has_upstream": true,
+    "last_commit": {
+      "sha": "ea69222",
+      "subject": "Merge pull request #33",
+      "committed": "2026-04-15T15:07:51+01:00"
+    },
+    "artifact_path": "/Users/user/treepad-workspaces/treepad-main.code-workspace",
+    "last_touched": "2026-04-13T20:07:27.882Z"
+  }
+]
+```

--- a/internal/commands/router.go
+++ b/internal/commands/router.go
@@ -9,5 +9,6 @@ func Router() []*cli.Command {
 		createCommand(),
 		removeCommand(),
 		pruneCommand(),
+		statusCommand(),
 	}
 }

--- a/internal/commands/status.go
+++ b/internal/commands/status.go
@@ -14,9 +14,9 @@ import (
 
 func statusCommand() *cli.Command {
 	return &cli.Command{
-		Name:   "status",
-		Usage:  "list all worktrees with branch, dirty state, ahead/behind, and last-touched",
-		Flags:  []cli.Flag{
+		Name:  "status",
+		Usage: "list all worktrees with branch, dirty state, ahead/behind, and last-touched",
+		Flags: []cli.Flag{
 			&cli.BoolFlag{Name: "json", Usage: "emit JSON instead of a table"},
 		},
 		Action: runStatus,

--- a/internal/commands/status.go
+++ b/internal/commands/status.go
@@ -1,0 +1,35 @@
+package commands
+
+import (
+	"context"
+	"os"
+
+	"github.com/urfave/cli/v3"
+
+	"treepad/internal/artifact"
+	internalsync "treepad/internal/sync"
+	"treepad/internal/treepad"
+	"treepad/internal/worktree"
+)
+
+func statusCommand() *cli.Command {
+	return &cli.Command{
+		Name:   "status",
+		Usage:  "list all worktrees with branch, dirty state, ahead/behind, and last-touched",
+		Flags:  []cli.Flag{
+			&cli.BoolFlag{Name: "json", Usage: "emit JSON instead of a table"},
+		},
+		Action: runStatus,
+	}
+}
+
+func runStatus(ctx context.Context, cmd *cli.Command) error {
+	runner := worktree.ExecRunner{}
+	svc := treepad.NewService(
+		runner,
+		internalsync.FileSyncer{},
+		artifact.ExecOpener{Runner: runner},
+		os.Stdout,
+	)
+	return svc.Status(ctx, treepad.StatusInput{JSON: cmd.Bool("json")})
+}

--- a/internal/treepad/service_status.go
+++ b/internal/treepad/service_status.go
@@ -22,16 +22,16 @@ type StatusInput struct {
 }
 
 type StatusRow struct {
-	Branch       string           `json:"branch"`
-	Path         string           `json:"path"`
-	IsMain       bool             `json:"is_main"`
-	Dirty        bool             `json:"dirty"`
-	Ahead        int              `json:"ahead"`
-	Behind       int              `json:"behind"`
-	HasUpstream  bool             `json:"has_upstream"`
+	Branch       string              `json:"branch"`
+	Path         string              `json:"path"`
+	IsMain       bool                `json:"is_main"`
+	Dirty        bool                `json:"dirty"`
+	Ahead        int                 `json:"ahead"`
+	Behind       int                 `json:"behind"`
+	HasUpstream  bool                `json:"has_upstream"`
 	LastCommit   worktree.CommitInfo `json:"last_commit"`
-	ArtifactPath string           `json:"artifact_path,omitempty"`
-	LastTouched  time.Time        `json:"last_touched"`
+	ArtifactPath string              `json:"artifact_path,omitempty"`
+	LastTouched  time.Time           `json:"last_touched"`
 }
 
 func (s *Service) Status(ctx context.Context, in StatusInput) error {
@@ -105,7 +105,7 @@ func (s *Service) Status(ctx context.Context, in StatusInput) error {
 
 func (s *Service) writeStatusTable(rows []StatusRow) error {
 	w := tabwriter.NewWriter(s.out, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "BRANCH\tSTATUS\tAHEAD/BEHIND\tLAST COMMIT\tTOUCHED\tPATH")
+	_, _ = fmt.Fprintln(w, "BRANCH\tSTATUS\tAHEAD/BEHIND\tLAST COMMIT\tTOUCHED\tPATH")
 
 	for _, r := range rows {
 		branch := r.Branch
@@ -137,7 +137,7 @@ func (s *Service) writeStatusTable(rows []StatusRow) error {
 			touched = since(r.LastTouched)
 		}
 
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
 			branch, status, aheadBehind, lastCommit, touched, collapsePath(r.Path))
 	}
 

--- a/internal/treepad/service_status.go
+++ b/internal/treepad/service_status.go
@@ -1,0 +1,167 @@
+package treepad
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"treepad/internal/artifact"
+	"treepad/internal/config"
+	"treepad/internal/slug"
+	"treepad/internal/worktree"
+)
+
+type StatusInput struct {
+	JSON      bool
+	OutputDir string
+}
+
+type StatusRow struct {
+	Branch       string           `json:"branch"`
+	Path         string           `json:"path"`
+	IsMain       bool             `json:"is_main"`
+	Dirty        bool             `json:"dirty"`
+	Ahead        int              `json:"ahead"`
+	Behind       int              `json:"behind"`
+	HasUpstream  bool             `json:"has_upstream"`
+	LastCommit   worktree.CommitInfo `json:"last_commit"`
+	ArtifactPath string           `json:"artifact_path,omitempty"`
+	LastTouched  time.Time        `json:"last_touched"`
+}
+
+func (s *Service) Status(ctx context.Context, in StatusInput) error {
+	worktrees, err := s.listWorktrees(ctx)
+	if err != nil {
+		return err
+	}
+
+	mainWT, err := worktree.MainWorktree(worktrees)
+	if err != nil {
+		return err
+	}
+
+	repoSlug := slug.Slug(filepath.Base(mainWT.Path))
+
+	outputDir, err := s.resolveOutputDir(in.OutputDir, repoSlug)
+	if err != nil {
+		return err
+	}
+
+	cfg, err := config.Load(mainWT.Path)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	spec := artifactSpec(cfg.Artifact)
+
+	rows := make([]StatusRow, 0, len(worktrees))
+	for _, wt := range worktrees {
+		row := StatusRow{
+			Branch: wt.Branch,
+			Path:   wt.Path,
+			IsMain: wt.IsMain,
+		}
+
+		row.Dirty, err = worktree.Dirty(ctx, s.runner, wt.Path)
+		if err != nil {
+			return err
+		}
+
+		row.Ahead, row.Behind, row.HasUpstream, err = worktree.AheadBehind(ctx, s.runner, wt.Path)
+		if err != nil {
+			return err
+		}
+
+		row.LastCommit, err = worktree.LastCommit(ctx, s.runner, wt.Path)
+		if err != nil {
+			return err
+		}
+
+		data := s.templateData(repoSlug, wt.Branch, wt.Path, outputDir)
+		artifactPath, ok, err := artifact.Path(spec, outputDir, data)
+		if err != nil {
+			return fmt.Errorf("resolve artifact path: %w", err)
+		}
+		if ok {
+			row.ArtifactPath = artifactPath
+			if info, statErr := os.Stat(artifactPath); statErr == nil {
+				row.LastTouched = info.ModTime()
+			}
+		}
+
+		rows = append(rows, row)
+	}
+
+	if in.JSON {
+		return json.NewEncoder(s.out).Encode(rows)
+	}
+	return s.writeStatusTable(rows)
+}
+
+func (s *Service) writeStatusTable(rows []StatusRow) error {
+	w := tabwriter.NewWriter(s.out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "BRANCH\tSTATUS\tAHEAD/BEHIND\tLAST COMMIT\tTOUCHED\tPATH")
+
+	for _, r := range rows {
+		branch := r.Branch
+		if r.IsMain {
+			branch += " *"
+		}
+
+		status := "clean"
+		if r.Dirty {
+			status = "dirty"
+		}
+
+		aheadBehind := "—"
+		if r.HasUpstream {
+			aheadBehind = fmt.Sprintf("↑%d ↓%d", r.Ahead, r.Behind)
+		}
+
+		lastCommit := "—"
+		if r.LastCommit.ShortSHA != "" {
+			subject := r.LastCommit.Subject
+			if len(subject) > 35 {
+				subject = subject[:35] + "…"
+			}
+			lastCommit = fmt.Sprintf("%s %s · %s", r.LastCommit.ShortSHA, subject, since(r.LastCommit.Committed))
+		}
+
+		touched := "—"
+		if !r.LastTouched.IsZero() {
+			touched = since(r.LastTouched)
+		}
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			branch, status, aheadBehind, lastCommit, touched, collapsePath(r.Path))
+	}
+
+	return w.Flush()
+}
+
+func since(t time.Time) string {
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}
+
+func collapsePath(path string) string {
+	home, err := os.UserHomeDir()
+	if err != nil || !strings.HasPrefix(path, home) {
+		return path
+	}
+	return "~" + path[len(home):]
+}

--- a/internal/treepad/service_test.go
+++ b/internal/treepad/service_test.go
@@ -547,6 +547,127 @@ func TestServicePrune(t *testing.T) {
 	}
 }
 
+func TestServiceStatus(t *testing.T) {
+	mainPath := t.TempDir()
+	if err := os.Mkdir(filepath.Join(mainPath, ".git"), 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	featPath := mainPath + "-feat"
+	outputDir := t.TempDir()
+	repoSlug := slug.Slug(filepath.Base(mainPath))
+	porcelain := twoWorktreePorcelainWithMain(mainPath, featPath)
+
+	// commitTime is used for two worktrees in the happy-path test.
+	commitOutput := func(sha, subject string) []byte {
+		return fmt.Appendf(nil, "%s\x00%s\x002024-06-01T12:00:00Z\n", sha, subject)
+	}
+
+	t.Run("renders table for two worktrees", func(t *testing.T) {
+		// main: clean, upstream (0 ahead, 1 behind)
+		// feat: dirty, no upstream
+		// artifact file for feat exists; main's does not
+		featArtifact := filepath.Join(outputDir, repoSlug+"-feat.code-workspace")
+		if err := os.WriteFile(featArtifact, []byte("{}"), 0o644); err != nil {
+			t.Fatalf("setup artifact: %v", err)
+		}
+
+		runner := &seqRunner{responses: []runResponse{
+			{output: porcelain},                        // git worktree list
+			{output: []byte("")},                       // dirty: main (clean)
+			{output: []byte("origin/main\n")},          // rev-parse @{upstream}: main
+			{output: []byte("0\t1\n")},                 // rev-list: main (0↑ 1↓)
+			{output: commitOutput("abc1234", "init")},  // git log: main
+			{output: []byte("M file.go\n")},            // dirty: feat
+			{err: errors.New("no upstream")},           // rev-parse @{upstream}: feat (none)
+			{output: commitOutput("def5678", "add x")}, // git log: feat
+		}}
+
+		var buf strings.Builder
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf)
+		err := svc.Status(context.Background(), StatusInput{OutputDir: outputDir})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if runner.idx != 8 {
+			t.Errorf("runner called %d times, want 8", runner.idx)
+		}
+		out := buf.String()
+		for _, want := range []string{"BRANCH", "main", "feat", "clean", "dirty", "↑0 ↓1", "—", "abc1234", "def5678"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("output missing %q:\n%s", want, out)
+			}
+		}
+	})
+
+	t.Run("json flag emits JSON array", func(t *testing.T) {
+		runner := &seqRunner{responses: []runResponse{
+			{output: porcelain},
+			{output: []byte("")},
+			{err: errors.New("no upstream")},
+			{output: commitOutput("abc1234", "init")},
+			{output: []byte("")},
+			{err: errors.New("no upstream")},
+			{output: commitOutput("def5678", "add x")},
+		}}
+		var buf strings.Builder
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf)
+		err := svc.Status(context.Background(), StatusInput{JSON: true, OutputDir: outputDir})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := buf.String()
+		if !strings.HasPrefix(out, "[") {
+			t.Errorf("expected JSON array, got: %s", out)
+		}
+		for _, want := range []string{"main", "feat", `"dirty"`, `"branch"`} {
+			if !strings.Contains(out, want) {
+				t.Errorf("JSON output missing %q:\n%s", want, out)
+			}
+		}
+	})
+
+	errorTests := []struct {
+		name    string
+		runner  *seqRunner
+		wantErr string
+	}{
+		{
+			name: "git worktree list fails",
+			runner: &seqRunner{responses: []runResponse{
+				{err: errors.New("git not found")},
+			}},
+			wantErr: "git not found",
+		},
+		{
+			name: "dirty probe fails",
+			runner: &seqRunner{responses: []runResponse{
+				{output: porcelain},
+				{err: errors.New("status failed")},
+			}},
+			wantErr: "status failed",
+		},
+		{
+			name: "last commit probe fails",
+			runner: &seqRunner{responses: []runResponse{
+				{output: porcelain},
+				{output: []byte("")},              // dirty: clean
+				{err: errors.New("no upstream")},  // no upstream
+				{err: errors.New("log failed")},   // log fails
+			}},
+			wantErr: "log failed",
+		},
+	}
+	for _, tt := range errorTests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := NewService(tt.runner, &fakeSyncer{}, &fakeOpener{}, io.Discard)
+			err := svc.Status(context.Background(), StatusInput{OutputDir: outputDir})
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("got error %v, want error containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestResolveSourceDir(t *testing.T) {
 	withMain := []worktree.Worktree{
 		{Path: "/repo/feat", Branch: "feat", IsMain: false},

--- a/internal/treepad/service_test.go
+++ b/internal/treepad/service_test.go
@@ -650,9 +650,9 @@ func TestServiceStatus(t *testing.T) {
 			name: "last commit probe fails",
 			runner: &seqRunner{responses: []runResponse{
 				{output: porcelain},
-				{output: []byte("")},              // dirty: clean
-				{err: errors.New("no upstream")},  // no upstream
-				{err: errors.New("log failed")},   // log fails
+				{output: []byte("")},             // dirty: clean
+				{err: errors.New("no upstream")}, // no upstream
+				{err: errors.New("log failed")},  // log fails
 			}},
 			wantErr: "log failed",
 		},

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -10,7 +10,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 )
 
 type CommandRunner interface {
@@ -122,6 +124,73 @@ func MergedBranches(ctx context.Context, runner CommandRunner, base string) ([]s
 		branches = append(branches, line)
 	}
 	return branches, nil
+}
+
+// CommitInfo holds summary information about a single git commit.
+type CommitInfo struct {
+	ShortSHA  string    `json:"sha"`
+	Subject   string    `json:"subject"`
+	Committed time.Time `json:"committed"`
+}
+
+// Dirty reports whether the worktree at path has uncommitted changes.
+func Dirty(ctx context.Context, runner CommandRunner, path string) (bool, error) {
+	out, err := runner.Run(ctx, "git", "-C", path, "status", "--porcelain")
+	if err != nil {
+		return false, fmt.Errorf("git status: %w", err)
+	}
+	return len(bytes.TrimSpace(out)) > 0, nil
+}
+
+// AheadBehind returns the number of commits the branch at path is ahead of and
+// behind its upstream. hasUpstream is false when no upstream is configured; this
+// is not an error.
+func AheadBehind(ctx context.Context, runner CommandRunner, path string) (ahead, behind int, hasUpstream bool, err error) {
+	if _, err := runner.Run(ctx, "git", "-C", path, "rev-parse", "--abbrev-ref", "@{upstream}"); err != nil {
+		return 0, 0, false, nil
+	}
+	out, err := runner.Run(ctx, "git", "-C", path, "rev-list", "--left-right", "--count", "HEAD...@{upstream}")
+	if err != nil {
+		return 0, 0, true, fmt.Errorf("git rev-list: %w", err)
+	}
+	parts := strings.Fields(strings.TrimSpace(string(out)))
+	if len(parts) != 2 {
+		return 0, 0, true, fmt.Errorf("unexpected rev-list output: %q", string(out))
+	}
+	a, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, true, fmt.Errorf("parse ahead count: %w", err)
+	}
+	b, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, true, fmt.Errorf("parse behind count: %w", err)
+	}
+	return a, b, true, nil
+}
+
+// LastCommit returns summary information about the HEAD commit of the worktree at path.
+func LastCommit(ctx context.Context, runner CommandRunner, path string) (CommitInfo, error) {
+	out, err := runner.Run(ctx, "git", "-C", path, "log", "-1", "--format=%h%x00%s%x00%cI")
+	if err != nil {
+		return CommitInfo{}, fmt.Errorf("git log: %w", err)
+	}
+	trimmed := strings.TrimRight(string(out), "\n")
+	if trimmed == "" {
+		return CommitInfo{}, nil
+	}
+	parts := strings.SplitN(trimmed, "\x00", 3)
+	if len(parts) != 3 {
+		return CommitInfo{}, fmt.Errorf("unexpected log output: %q", string(out))
+	}
+	committed, err := time.Parse(time.RFC3339, parts[2])
+	if err != nil {
+		return CommitInfo{}, fmt.Errorf("parse commit time %q: %w", parts[2], err)
+	}
+	return CommitInfo{
+		ShortSHA:  parts[0],
+		Subject:   parts[1],
+		Committed: committed,
+	}, nil
 }
 
 func isMainWorktree(path string) bool {

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -3,8 +3,27 @@ package worktree
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
+	"time"
 )
+
+type seqRunner struct {
+	responses []struct {
+		output []byte
+		err    error
+	}
+	idx int
+}
+
+func (s *seqRunner) Run(_ context.Context, _ string, _ ...string) ([]byte, error) {
+	if s.idx >= len(s.responses) {
+		return nil, fmt.Errorf("unexpected runner call %d", s.idx)
+	}
+	r := s.responses[s.idx]
+	s.idx++
+	return r.output, r.err
+}
 
 type fakeRunner struct {
 	output []byte
@@ -202,6 +221,190 @@ func TestMainWorktree(t *testing.T) {
 			}
 			if got.Path != tt.wantPath {
 				t.Errorf("Path = %q, want %q", got.Path, tt.wantPath)
+			}
+		})
+	}
+}
+
+func TestDirty(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		output  []byte
+		err     error
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:   "clean worktree",
+			output: []byte(""),
+			want:   false,
+		},
+		{
+			name:   "dirty worktree",
+			output: []byte("M file.go\n"),
+			want:   true,
+		},
+		{
+			name:   "only whitespace",
+			output: []byte("\n"),
+			want:   false,
+		},
+		{
+			name:    "runner error",
+			err:     errors.New("exit status 128"),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Dirty(ctx, fakeRunner{output: tt.output, err: tt.err}, "/repo")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("Dirty() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAheadBehind(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		responses   []struct{ output []byte; err error }
+		wantAhead   int
+		wantBehind  int
+		wantUpstream bool
+		wantErr     bool
+	}{
+		{
+			name: "no upstream configured",
+			responses: []struct{ output []byte; err error }{
+				{err: errors.New("fatal: no upstream configured")},
+			},
+			wantUpstream: false,
+		},
+		{
+			name: "ahead 2, behind 1",
+			responses: []struct{ output []byte; err error }{
+				{output: []byte("origin/main\n")},
+				{output: []byte("2\t1\n")},
+			},
+			wantAhead:    2,
+			wantBehind:   1,
+			wantUpstream: true,
+		},
+		{
+			name: "in sync",
+			responses: []struct{ output []byte; err error }{
+				{output: []byte("origin/main\n")},
+				{output: []byte("0\t0\n")},
+			},
+			wantAhead:    0,
+			wantBehind:   0,
+			wantUpstream: true,
+		},
+		{
+			name: "rev-list error",
+			responses: []struct{ output []byte; err error }{
+				{output: []byte("origin/main\n")},
+				{err: errors.New("rev-list failed")},
+			},
+			wantUpstream: true,
+			wantErr:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &seqRunner{}
+			for _, r := range tt.responses {
+				runner.responses = append(runner.responses, r)
+			}
+			ahead, behind, hasUpstream, err := AheadBehind(ctx, runner, "/repo")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if hasUpstream != tt.wantUpstream {
+				t.Errorf("hasUpstream = %v, want %v", hasUpstream, tt.wantUpstream)
+			}
+			if ahead != tt.wantAhead {
+				t.Errorf("ahead = %d, want %d", ahead, tt.wantAhead)
+			}
+			if behind != tt.wantBehind {
+				t.Errorf("behind = %d, want %d", behind, tt.wantBehind)
+			}
+		})
+	}
+}
+
+func TestLastCommit(t *testing.T) {
+	ctx := context.Background()
+	commitTime, _ := time.Parse(time.RFC3339, "2024-06-01T12:00:00Z")
+
+	tests := []struct {
+		name    string
+		output  []byte
+		err     error
+		want    CommitInfo
+		wantErr bool
+	}{
+		{
+			name:   "happy path",
+			output: []byte("abc1234\x00fix: correct thing\x002024-06-01T12:00:00Z\n"),
+			want:   CommitInfo{ShortSHA: "abc1234", Subject: "fix: correct thing", Committed: commitTime},
+		},
+		{
+			name:   "empty output (no commits)",
+			output: []byte(""),
+			want:   CommitInfo{},
+		},
+		{
+			name:    "bad timestamp",
+			output:  []byte("abc1234\x00subject\x00not-a-date\n"),
+			wantErr: true,
+		},
+		{
+			name:    "runner error",
+			err:     errors.New("exit status 128"),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := LastCommit(ctx, fakeRunner{output: tt.output, err: tt.err}, "/repo")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.ShortSHA != tt.want.ShortSHA {
+				t.Errorf("ShortSHA = %q, want %q", got.ShortSHA, tt.want.ShortSHA)
+			}
+			if got.Subject != tt.want.Subject {
+				t.Errorf("Subject = %q, want %q", got.Subject, tt.want.Subject)
+			}
+			if !got.Committed.Equal(tt.want.Committed) {
+				t.Errorf("Committed = %v, want %v", got.Committed, tt.want.Committed)
 			}
 		})
 	}

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -280,23 +280,32 @@ func TestAheadBehind(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name        string
-		responses   []struct{ output []byte; err error }
-		wantAhead   int
-		wantBehind  int
+		name      string
+		responses []struct {
+			output []byte
+			err    error
+		}
+		wantAhead    int
+		wantBehind   int
 		wantUpstream bool
-		wantErr     bool
+		wantErr      bool
 	}{
 		{
 			name: "no upstream configured",
-			responses: []struct{ output []byte; err error }{
+			responses: []struct {
+				output []byte
+				err    error
+			}{
 				{err: errors.New("fatal: no upstream configured")},
 			},
 			wantUpstream: false,
 		},
 		{
 			name: "ahead 2, behind 1",
-			responses: []struct{ output []byte; err error }{
+			responses: []struct {
+				output []byte
+				err    error
+			}{
 				{output: []byte("origin/main\n")},
 				{output: []byte("2\t1\n")},
 			},
@@ -306,7 +315,10 @@ func TestAheadBehind(t *testing.T) {
 		},
 		{
 			name: "in sync",
-			responses: []struct{ output []byte; err error }{
+			responses: []struct {
+				output []byte
+				err    error
+			}{
 				{output: []byte("origin/main\n")},
 				{output: []byte("0\t0\n")},
 			},
@@ -316,7 +328,10 @@ func TestAheadBehind(t *testing.T) {
 		},
 		{
 			name: "rev-list error",
-			responses: []struct{ output []byte; err error }{
+			responses: []struct {
+				output []byte
+				err    error
+			}{
 				{output: []byte("origin/main\n")},
 				{err: errors.New("rev-list failed")},
 			},
@@ -327,9 +342,7 @@ func TestAheadBehind(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			runner := &seqRunner{}
-			for _, r := range tt.responses {
-				runner.responses = append(runner.responses, r)
-			}
+			runner.responses = append(runner.responses, tt.responses...)
 			ahead, behind, hasUpstream, err := AheadBehind(ctx, runner, "/repo")
 			if tt.wantErr {
 				if err == nil {


### PR DESCRIPTION
## Summary

- Adds `treepad status`: lists all worktrees with branch, dirty state, ahead/behind vs `@{upstream}`, last commit, and artifact file mtime (agent heartbeat)
- `--json` flag emits a structured array for scripting and agents
- New git probes in `internal/worktree`: `Dirty`, `AheadBehind`, `LastCommit`
- `Service.Status` in `internal/treepad/service_status.go` — tabwriter table + JSON renderer
- Full unit tests at worktree and service layers
- Docs updated: `README.md`, `docs/commands.md`, `CODEMAP.md`

This is slice 1 of the ideation roadmap (`ideas/2026-04-15-ideate.md`) — the repo-level truth framing before heavier foundations (state.toml, board).

## Test plan

- [ ] `go test ./...` passes
- [ ] `treepad status` renders aligned table with correct columns
- [ ] `treepad status --json | jq .` emits valid structured JSON
- [ ] `STATUS` column shows `dirty` after modifying a file in a worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)