### PR TITLE
feat: add prune --all to force-remove all non-main worktrees

### DIFF
--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -24,7 +24,8 @@ Central location for all CLI command definitions. Separates CLI wiring from busi
 - `workspaceCommand()` — top-level workspace command definition
 - `runWorkspace(ctx, cmd)` — action handler for workspace operations
   - Parses flags: `--use-current`, `--sync-only`, `--output-dir`, `--include`
-  - Instantiates `treepad.Service` and calls `Generate()`
+  - Instantiates `treepad.Service` with `os.Stdout` and `os.Stdin`
+  - Calls `Generate()`
   - Creates instances of `worktree.ExecRunner`, `sync.FileSyncer`
 
 ### `new.go`
@@ -32,7 +33,8 @@ Central location for all CLI command definitions. Separates CLI wiring from busi
 - `newCommand()` — top-level new command definition
 - `runNew(ctx, cmd)` — action handler for creating new worktrees
   - Parses flags: `--base` (default: "main"), `--open`, `--current (-c)`
-  - Instantiates `treepad.Service` and calls `New()`
+  - Instantiates `treepad.Service` with `os.Stdout` and `os.Stdin`
+  - Calls `New()`
   - Creates instances of `worktree.ExecRunner`, `sync.FileSyncer`, `artifact.ExecOpener`
 
 ### `shell_init.go`
@@ -45,15 +47,17 @@ Central location for all CLI command definitions. Separates CLI wiring from busi
 - `removeCommand()` — top-level remove command definition
 - `runRemove(ctx, cmd)` — action handler for removing worktrees
   - Parses branch argument (required)
-  - Instantiates `treepad.Service` and calls `Remove()`
+  - Instantiates `treepad.Service` with `os.Stdout` and `os.Stdin`
+  - Calls `Remove()`
   - Creates instances of `worktree.ExecRunner`, `sync.FileSyncer`
 
 ### `prune.go`
 
 - `pruneCommand()` — top-level prune command definition
 - `runPrune(ctx, cmd)` — action handler for pruning merged worktrees
-  - Parses flags: `--base` (default: "main"), `--dry-run`
-  - Instantiates `treepad.Service` and calls `Prune()`
+  - Parses flags: `--base` (default: "main"), `--dry-run`, `--all` (force-remove all non-main)
+  - Instantiates `treepad.Service` with `os.Stdout` and `os.Stdin`
+  - Calls `Prune()`
   - Creates instances of `worktree.ExecRunner`, `sync.FileSyncer`, `artifact.ExecOpener`
 
 ### `config.go`
@@ -72,7 +76,8 @@ Central location for all CLI command definitions. Separates CLI wiring from busi
 - `statusCommand()` — top-level status command definition
 - `runStatus(ctx, cmd)` — action handler for listing worktree status
   - Parses flag: `--json` (emit JSON instead of table)
-  - Instantiates `treepad.Service` and calls `Status()`
+  - Instantiates `treepad.Service` with `os.Stdout` and `os.Stdin`
+  - Calls `Status()`
   - Creates instances of `worktree.ExecRunner`, `sync.FileSyncer`, `artifact.ExecOpener`
 
 ## Config Package (`internal/config/`)
@@ -118,7 +123,8 @@ Pure business logic for worktree syncing and artifact file generation. Formerly 
 ### `service.go`
 
 - `Service` struct — coordinates syncing and artifact generation
-  - `NewService(runner, syncer, opener, out)` — constructor
+  - Fields: `runner` (CommandRunner), `syncer` (Syncer), `opener` (Opener), `out` (io.Writer), `in` (io.Reader)
+  - `NewService(runner, syncer, opener, out, in)` — constructor takes io.Reader for stdin access
   - `Generate(ctx, GenerateInput)` — generates artifact files and syncs configs
     - Input: `UseCurrentDir`, `SourcePath`, `SyncOnly`, `OutputDir`, `ExtraPatterns`
     - Resolves config source, loads config, syncs files, generates artifact files
@@ -129,9 +135,10 @@ Pure business logic for worktree syncing and artifact file generation. Formerly 
     - Input: `Branch`, `OutputDir`, `Cwd` (for testing)
     - Pre-flight guards: prevents removing main worktree, prevents removing from within the target worktree
     - Three-step removal: git worktree remove → delete artifact file → git branch -d
-  - `Prune(ctx, PruneInput)` — batch removes worktrees whose branches are merged
-    - Input: `Base`, `OutputDir`, `DryRun`, `Cwd` (for testing)
-    - Finds merged branches, filters out main/detached/current worktree
+  - `Prune(ctx, PruneInput)` — batch removes worktrees or force-removes all non-main
+    - Input: `Base`, `OutputDir`, `DryRun`, `All` (force-remove all non-main), `Cwd` (for testing)
+    - If `All=true`: validates running from main worktree, lists all non-main worktrees, prompts for confirmation, force-removes all via `forceRemoveWorktree()`
+    - If `All=false`: finds merged branches, filters out main/detached/current worktree
     - Executes removals by default; `DryRun: true` previews without removing
     - Returns error if any removals fail (after attempting all)
   - `Status(ctx, StatusInput)` — lists all worktrees with repo-wide status snapshot
@@ -139,7 +146,9 @@ Pure business logic for worktree syncing and artifact file generation. Formerly 
     - Output: builds `[]StatusRow` with branch, dirty state, ahead/behind count, last commit info, artifact mtime
     - Renders as aligned table via `text/tabwriter` by default, or JSON array with `--json` flag
 - Private helpers:
-  - `removeWorktree(ctx, target, mainWT, outputDir)` — removes a single worktree, deletes artifact, deletes branch
+  - `removeWorktree(ctx, target, mainWT, outputDir)` — removes a single worktree (merge-safe removal), deletes artifact, deletes branch
+  - `forceRemoveWorktree(ctx, target, mainWT, outputDir)` — force-removes a worktree via `git worktree remove --force`, deletes artifact, force-deletes branch via `git branch -D`
+  - `pruneAll(ctx, worktrees, mainWT, outputDir, cwd, dryRun)` — helper for `--all` mode; lists candidates, prompts user, force-removes each
   - `listWorktrees(ctx)` — lists all worktrees in repo
   - `resolveOutputDir(explicit, repoSlug)` — resolves artifact output directory
   - `loadAndSync(sourceDir, extraPatterns, targets)` — loads config and syncs to targets; returns `config.Config` so artifact config is available
@@ -234,7 +243,8 @@ treepad [--verbose] <command>
 ├── remove <branch>
 ├── prune [options]
 │   ├── --base (default: main)
-│   └── --dry-run
+│   ├── --dry-run
+│   └── --all (force-remove all non-main, must be from main)
 ├── status [options]
 │   └── --json
 └── config
@@ -305,17 +315,24 @@ treepad [--verbose] <command>
    - Deletes artifact file from output directory (missing file is not an error)
    - Deletes branch locally via `git branch -d`
 
-## Data Flow Example: `treepad prune [--base main] [--dry-run]`
+## Data Flow Example: `treepad prune [--base main] [--dry-run] [--all]`
 
 1. `main.go` parses flags and calls `commands.Router()`
 2. `commands.pruneCommand()` defines CLI interface
 3. `runPrune()` parses flags, instantiates `treepad.Service`, calls `Prune()`
-4. `Service.Prune()` executes:
-   - Lists all worktrees via `worktree.List()`
-   - Gets merged branches via `worktree.MergedBranches(ctx, runner, base)`
-   - Filters candidates: merged, not main, not detached, not current worktree
-   - If `--dry-run` flag set, prints candidates and returns
-   - Otherwise removes each candidate via `removeWorktree()`
+4. `Service.Prune()` dispatches based on `All` flag:
+   - **If `--all` flag set:** calls `pruneAll()`
+     - Validates running from main worktree (safety guard)
+     - Lists all non-main worktrees
+     - Displays candidates and prompts user: "continue? [y/N]:"
+     - If confirmed, force-removes each via `forceRemoveWorktree()` (git worktree remove --force, git branch -D)
+     - If not confirmed, outputs "aborted" and returns
+   - **If `--all` flag not set:** standard merge-based mode
+     - Lists all worktrees via `worktree.List()`
+     - Gets merged branches via `worktree.MergedBranches(ctx, runner, base)`
+     - Filters candidates: merged, not main, not detached, not current worktree
+     - If `--dry-run` flag set, prints candidates and returns
+     - Otherwise removes each candidate via `removeWorktree()` (safe removal via git worktree remove, git branch -d)
    - Returns error if any removals failed
 
 ## Data Flow Example: `treepad status [--json]`
@@ -336,4 +353,4 @@ treepad [--verbose] <command>
 
 ---
 
-**Last Updated:** April 15, 2026 (added `status` command for repo-wide worktree status snapshot)
+**Last Updated:** April 15, 2026 (added `--all` flag to `prune` command for force-removing all non-main worktrees with confirmation prompt; added `io.Reader` to `Service` for stdin access)

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ cd ../main-repo
 treepad remove feature-x
 ```
 
-**`prune`** — Remove all worktrees whose branches are merged into a base branch:
+**`prune`** — Remove all worktrees whose branches are merged into a base branch, or force-remove all non-main worktrees:
 
 ```bash
 # Remove all worktrees whose branches are merged into main
@@ -119,6 +119,9 @@ treepad prune --dry-run
 
 # Check merges against a different base branch
 treepad prune --base develop
+
+# Force-remove all non-main worktrees (with confirmation)
+treepad prune --all
 ```
 
 **`status`** — List all worktrees with their branch, dirty state, ahead/behind count, and last commit:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -212,13 +212,13 @@ cannot remove the worktree you are currently in; cd elsewhere first
 
 ## prune
 
-Remove all worktrees whose branches are already merged into a base branch. Useful for batch-cleaning completed work.
+Remove all worktrees whose branches are already merged into a base branch, or force-remove all non-main worktrees. Useful for batch-cleaning completed work.
 
 ```
 treepad prune [options]
 ```
 
-Automatically identifies and removes worktrees whose branches have been merged into a base branch (default: `main`). Executes removals directly; pass `--dry-run` to preview without making changes.
+Automatically identifies and removes worktrees whose branches have been merged into a base branch (default: `main`). Executes removals directly; pass `--dry-run` to preview without making changes. Use `--all` to force-remove all non-main worktrees (with confirmation prompt).
 
 ### Flags
 
@@ -226,13 +226,20 @@ Automatically identifies and removes worktrees whose branches have been merged i
 |------|-------------|
 | `--base` | Ref to check merges against (default: `main`) |
 | `--dry-run` | Preview removals without executing |
+| `--all` | Force-remove all non-main worktrees regardless of merge status (must be run from main worktree, requires confirmation) |
 
 ### Filtering
 
-Prune automatically skips:
-- The main worktree
-- Detached HEAD worktrees
-- The worktree you are currently in (continues to next rather than failing)
+When not using `--all`:
+- The main worktree is automatically skipped
+- Detached HEAD worktrees are skipped
+- The worktree you are currently in is skipped (continues to next rather than failing)
+
+When using `--all`:
+- Only the main worktree is preserved
+- Detached HEAD worktrees are still removed
+- Must be invoked from the main worktree (guards against removal by accident)
+- Requires interactive confirmation before proceeding
 
 ### Examples
 
@@ -248,11 +255,17 @@ treepad prune --base develop
 
 # Preview against a different base
 treepad prune --base develop --dry-run
+
+# Force-remove all non-main worktrees (with confirmation)
+treepad prune --all
+
+# Preview force-removal without executing
+treepad prune --all --dry-run
 ```
 
 ### Output Examples
 
-**Execution output (default):**
+**Execution output (default, merge-based):**
 
 ```
 removed worktree: /path/to/repo/repo-feature-x
@@ -276,9 +289,34 @@ would remove: feature-y (/path/to/repo/repo-feature-y)
 no merged worktrees to remove
 ```
 
+**Force-remove all (`--all`) execution:**
+
+```
+the following worktrees will be force-removed:
+  feature-x  /path/to/repo/repo-feature-x
+  feature-y  /path/to/repo/repo-feature-y
+continue? [y/N]: y
+removed worktree: /path/to/repo/repo-feature-x
+removed artifact: /home/user/repo-workspaces/repo-feature-x.code-workspace
+deleted branch: feature-x
+removed worktree: /path/to/repo/repo-feature-y
+removed artifact: /home/user/repo-workspaces/repo-feature-y.code-workspace
+deleted branch: feature-y
+```
+
+**Force-remove all (`--all`) aborted:**
+
+```
+the following worktrees will be force-removed:
+  feature-x  /path/to/repo/repo-feature-x
+  feature-y  /path/to/repo/repo-feature-y
+continue? [y/N]: n
+aborted
+```
+
 ### Skipping current worktree
 
-If you're currently inside a merged worktree, prune skips it and continues with the rest:
+If you're currently inside a merged worktree (merge-based mode), prune skips it and continues with the rest:
 
 ```
 skipping feature-x: currently in this worktree

--- a/internal/commands/cd.go
+++ b/internal/commands/cd.go
@@ -34,6 +34,7 @@ func runCD(ctx context.Context, cmd *cli.Command) error {
 		internalsync.FileSyncer{},
 		artifact.ExecOpener{Runner: runner},
 		os.Stdout,
+		os.Stdin,
 	)
 	return svc.CD(ctx, treepad.CDInput{Branch: branch})
 }

--- a/internal/commands/new.go
+++ b/internal/commands/new.go
@@ -51,6 +51,7 @@ func runNew(ctx context.Context, cmd *cli.Command) error {
 		internalsync.FileSyncer{},
 		artifact.ExecOpener{Runner: runner},
 		os.Stdout,
+		os.Stdin,
 	)
 	return svc.New(ctx, treepad.NewInput{
 		Branch:  branch,

--- a/internal/commands/prune.go
+++ b/internal/commands/prune.go
@@ -19,6 +19,7 @@ func pruneCommand() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{Name: "base", Value: "main", Usage: "base branch to check merges against"},
 			&cli.BoolFlag{Name: "dry-run", Usage: "preview removals without executing"},
+			&cli.BoolFlag{Name: "all", Usage: "force-remove all non-main worktrees (must be run from main)"},
 		},
 		Action: runPrune,
 	}
@@ -31,9 +32,11 @@ func runPrune(ctx context.Context, cmd *cli.Command) error {
 		internalsync.FileSyncer{},
 		artifact.ExecOpener{Runner: runner},
 		os.Stdout,
+		os.Stdin,
 	)
 	return svc.Prune(ctx, treepad.PruneInput{
 		Base:   cmd.String("base"),
 		DryRun: cmd.Bool("dry-run"),
+		All:    cmd.Bool("all"),
 	})
 }

--- a/internal/commands/remove.go
+++ b/internal/commands/remove.go
@@ -34,6 +34,7 @@ func runRemove(ctx context.Context, cmd *cli.Command) error {
 		internalsync.FileSyncer{},
 		artifact.ExecOpener{Runner: runner},
 		os.Stdout,
+		os.Stdin,
 	)
 	return svc.Remove(ctx, treepad.RemoveInput{Branch: branch})
 }

--- a/internal/commands/status.go
+++ b/internal/commands/status.go
@@ -30,6 +30,7 @@ func runStatus(ctx context.Context, cmd *cli.Command) error {
 		internalsync.FileSyncer{},
 		artifact.ExecOpener{Runner: runner},
 		os.Stdout,
+		os.Stdin,
 	)
 	return svc.Status(ctx, treepad.StatusInput{JSON: cmd.Bool("json")})
 }

--- a/internal/commands/workspace.go
+++ b/internal/commands/workspace.go
@@ -49,7 +49,7 @@ func runWorkspace(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("--use-current and a source path argument are mutually exclusive")
 	}
 
-	svc := treepad.NewService(worktree.ExecRunner{}, internalsync.FileSyncer{}, nil, os.Stdout)
+	svc := treepad.NewService(worktree.ExecRunner{}, internalsync.FileSyncer{}, nil, os.Stdout, os.Stdin)
 	return svc.Generate(ctx, treepad.GenerateInput{
 		UseCurrentDir: useCurrentFlag,
 		SourcePath:    sourcePath,

--- a/internal/treepad/service.go
+++ b/internal/treepad/service.go
@@ -1,6 +1,7 @@
 package treepad
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -22,10 +23,11 @@ type Service struct {
 	syncer internalsync.Syncer
 	opener artifact.Opener
 	out    io.Writer
+	in     io.Reader
 }
 
-func NewService(runner worktree.CommandRunner, syncer internalsync.Syncer, opener artifact.Opener, out io.Writer) *Service {
-	return &Service{runner: runner, syncer: syncer, opener: opener, out: out}
+func NewService(runner worktree.CommandRunner, syncer internalsync.Syncer, opener artifact.Opener, out io.Writer, in io.Reader) *Service {
+	return &Service{runner: runner, syncer: syncer, opener: opener, out: out, in: in}
 }
 
 type GenerateInput struct {
@@ -55,6 +57,7 @@ type PruneInput struct {
 	Base      string // branch to check merges against, e.g. "main"
 	OutputDir string
 	DryRun    bool
+	All       bool // force-remove all non-main worktrees regardless of merge status
 	// Cwd overrides os.Getwd for testing the cwd-inside guard.
 	Cwd string
 }
@@ -241,6 +244,18 @@ func (s *Service) Prune(ctx context.Context, in PruneInput) error {
 		return err
 	}
 
+	cwd := in.Cwd
+	if cwd == "" {
+		cwd, err = os.Getwd()
+		if err != nil {
+			return fmt.Errorf("get current directory: %w", err)
+		}
+	}
+
+	if in.All {
+		return s.pruneAll(ctx, worktrees, mainWT, outputDir, cwd, in.DryRun)
+	}
+
 	merged, err := worktree.MergedBranches(ctx, s.runner, in.Base)
 	if err != nil {
 		return err
@@ -249,14 +264,6 @@ func (s *Service) Prune(ctx context.Context, in PruneInput) error {
 	mergedSet := make(map[string]bool, len(merged))
 	for _, b := range merged {
 		mergedSet[b] = true
-	}
-
-	cwd := in.Cwd
-	if cwd == "" {
-		cwd, err = os.Getwd()
-		if err != nil {
-			return fmt.Errorf("get current directory: %w", err)
-		}
 	}
 
 	var candidates []worktree.Worktree
@@ -300,6 +307,58 @@ func (s *Service) Prune(ctx context.Context, in PruneInput) error {
 	return nil
 }
 
+func (s *Service) pruneAll(ctx context.Context, worktrees []worktree.Worktree, mainWT worktree.Worktree, outputDir, cwd string, dryRun bool) error {
+	// Must be invoked from the main worktree.
+	if rel, relErr := filepath.Rel(mainWT.Path, cwd); relErr != nil || strings.HasPrefix(rel, "..") {
+		return fmt.Errorf("--all must be run from the main worktree (%s)", mainWT.Path)
+	}
+
+	var candidates []worktree.Worktree
+	for _, wt := range worktrees {
+		if wt.IsMain || wt.Branch == mainWT.Branch || wt.Branch == "(detached)" {
+			continue
+		}
+		candidates = append(candidates, wt)
+	}
+
+	if len(candidates) == 0 {
+		_, _ = fmt.Fprintln(s.out, "no worktrees to remove")
+		return nil
+	}
+
+	if dryRun {
+		for _, c := range candidates {
+			_, _ = fmt.Fprintf(s.out, "would remove: %s (%s)\n", c.Branch, c.Path)
+		}
+		return nil
+	}
+
+	_, _ = fmt.Fprintln(s.out, "the following worktrees will be force-removed:")
+	for _, c := range candidates {
+		_, _ = fmt.Fprintf(s.out, "  %s  %s\n", c.Branch, c.Path)
+	}
+	_, _ = fmt.Fprint(s.out, "continue? [y/N]: ")
+
+	line, _ := bufio.NewReader(s.in).ReadString('\n')
+	if answer := strings.ToLower(strings.TrimSpace(line)); answer != "y" && answer != "yes" {
+		_, _ = fmt.Fprintln(s.out, "aborted")
+		return nil
+	}
+
+	var failed []string
+	for _, c := range candidates {
+		if err := s.forceRemoveWorktree(ctx, c, mainWT, outputDir); err != nil {
+			_, _ = fmt.Fprintf(s.out, "error removing %s: %v\n", c.Branch, err)
+			failed = append(failed, c.Branch)
+		}
+	}
+
+	if len(failed) > 0 {
+		return fmt.Errorf("failed to remove: %s", strings.Join(failed, ", "))
+	}
+	return nil
+}
+
 func (s *Service) removeWorktree(ctx context.Context, target worktree.Worktree, mainWT worktree.Worktree, outputDir string) error {
 	if _, err := s.runner.Run(ctx, "git", "worktree", "remove", target.Path); err != nil {
 		return fmt.Errorf("git worktree remove: %w", err)
@@ -326,6 +385,38 @@ func (s *Service) removeWorktree(ctx context.Context, target worktree.Worktree, 
 
 	if _, err := s.runner.Run(ctx, "git", "branch", "-d", target.Branch); err != nil {
 		return fmt.Errorf("git branch -d: %w", err)
+	}
+	_, _ = fmt.Fprintf(s.out, "deleted branch: %s\n", target.Branch)
+
+	return nil
+}
+
+func (s *Service) forceRemoveWorktree(ctx context.Context, target worktree.Worktree, mainWT worktree.Worktree, outputDir string) error {
+	if _, err := s.runner.Run(ctx, "git", "worktree", "remove", "--force", target.Path); err != nil {
+		return fmt.Errorf("git worktree remove --force: %w", err)
+	}
+	_, _ = fmt.Fprintf(s.out, "removed worktree: %s\n", target.Path)
+
+	cfg, err := config.Load(mainWT.Path)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	repoSlug := slug.Slug(filepath.Base(mainWT.Path))
+	data := s.templateData(repoSlug, target.Branch, target.Path, outputDir)
+	artifactPath, ok, err := artifact.Path(artifactSpec(cfg.Artifact), outputDir, data)
+	if err != nil {
+		return fmt.Errorf("resolve artifact path: %w", err)
+	}
+	if ok {
+		if err := os.Remove(artifactPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove artifact: %w", err)
+		}
+		_, _ = fmt.Fprintf(s.out, "removed artifact: %s\n", artifactPath)
+	}
+
+	if _, err := s.runner.Run(ctx, "git", "branch", "-D", target.Branch); err != nil {
+		return fmt.Errorf("git branch -D: %w", err)
 	}
 	_, _ = fmt.Fprintf(s.out, "deleted branch: %s\n", target.Branch)
 

--- a/internal/treepad/service_cd_test.go
+++ b/internal/treepad/service_cd_test.go
@@ -31,7 +31,7 @@ func TestServiceCD(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var out bytes.Buffer
-			svc := NewService(fakeRunner{output: twoWorktreePorcelain}, &fakeSyncer{}, nil, &out)
+			svc := NewService(fakeRunner{output: twoWorktreePorcelain}, &fakeSyncer{}, nil, &out, strings.NewReader(""))
 
 			err := svc.CD(context.Background(), CDInput{Branch: tt.branch})
 

--- a/internal/treepad/service_test.go
+++ b/internal/treepad/service_test.go
@@ -85,7 +85,19 @@ func mainWorktreePorcelain(mainPath string) []byte {
 
 func newTestService(t *testing.T, runner worktree.CommandRunner, syncer internalsync.Syncer, opener artifact.Opener) *Service {
 	t.Helper()
-	return NewService(runner, syncer, opener, io.Discard)
+	return NewService(runner, syncer, opener, io.Discard, strings.NewReader(""))
+}
+
+// recordingRunner records every Run call and delegates to an inner seqRunner.
+type recordingRunner struct {
+	inner *seqRunner
+	calls [][]string // each entry is [name, args...]
+}
+
+func (r *recordingRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	entry := append([]string{name}, args...)
+	r.calls = append(r.calls, entry)
+	return r.inner.Run(ctx, name, args...)
 }
 
 func TestServiceGenerate(t *testing.T) {
@@ -160,7 +172,7 @@ func TestServiceNew(t *testing.T) {
 		}}
 		syn := &fakeSyncer{}
 		opener := &fakeOpener{}
-		svc := NewService(runner, syn, opener, io.Discard)
+		svc := NewService(runner, syn, opener, io.Discard, strings.NewReader(""))
 
 		err := svc.New(context.Background(), NewInput{
 			Branch:    "feature/auth",
@@ -187,7 +199,7 @@ func TestServiceNew(t *testing.T) {
 			{output: nil},
 		}}
 		opener := &fakeOpener{}
-		svc := NewService(runner, &fakeSyncer{}, opener, io.Discard)
+		svc := NewService(runner, &fakeSyncer{}, opener, io.Discard, strings.NewReader(""))
 
 		err := svc.New(context.Background(), NewInput{
 			Branch:    "feature/auth",
@@ -213,7 +225,7 @@ func TestServiceNew(t *testing.T) {
 			{output: nil},
 		}}
 		var buf strings.Builder
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf)
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
 
 		err := svc.New(context.Background(), NewInput{
 			Branch:    "feature/auth",
@@ -234,7 +246,7 @@ func TestServiceNew(t *testing.T) {
 			{output: nil},
 		}}
 		var buf strings.Builder
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf)
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
 
 		err := svc.New(context.Background(), NewInput{
 			Branch:    "feature/auth",
@@ -285,7 +297,7 @@ func TestServiceNew(t *testing.T) {
 	}
 	for _, tt := range errorTests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := NewService(tt.runner, tt.syncer, &fakeOpener{}, io.Discard)
+			svc := NewService(tt.runner, tt.syncer, &fakeOpener{}, io.Discard, strings.NewReader(""))
 			err := svc.New(context.Background(), NewInput{
 				Branch:    "feature/auth",
 				Base:      "main",
@@ -327,7 +339,7 @@ func TestServiceRemove(t *testing.T) {
 			{},                  // git worktree remove
 			{},                  // git branch -d
 		}}
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard)
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
 
 		err := svc.Remove(context.Background(), RemoveInput{Branch: "feat", OutputDir: outputDir})
 		if err != nil {
@@ -348,7 +360,7 @@ func TestServiceRemove(t *testing.T) {
 			{},
 			{},
 		}}
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard)
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
 
 		err := svc.Remove(context.Background(), RemoveInput{Branch: "feat", OutputDir: outputDir})
 		if err != nil {
@@ -408,7 +420,7 @@ func TestServiceRemove(t *testing.T) {
 	}
 	for _, tt := range errorTests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := NewService(tt.runner, &fakeSyncer{}, &fakeOpener{}, io.Discard)
+			svc := NewService(tt.runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
 			err := svc.Remove(context.Background(), RemoveInput{Branch: tt.branch, OutputDir: outputDir})
 			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 				t.Errorf("got error %v, want error containing %q", err, tt.wantErr)
@@ -420,7 +432,7 @@ func TestServiceRemove(t *testing.T) {
 		runner := &seqRunner{responses: []runResponse{
 			{output: porcelain},
 		}}
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard)
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
 
 		err := svc.Remove(context.Background(), RemoveInput{
 			Branch:    "feat",
@@ -460,7 +472,7 @@ func TestServicePrune(t *testing.T) {
 			{output: twoPorcelain},     // git worktree list
 			{output: []byte("feat\n")}, // git branch --merged
 		}}
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard)
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
 
 		err := svc.Prune(context.Background(), PruneInput{Base: "main", OutputDir: outputDir, DryRun: true})
 		if err != nil {
@@ -483,7 +495,7 @@ func TestServicePrune(t *testing.T) {
 			{},                         // git worktree remove
 			{},                         // git branch -d
 		}}
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard)
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
 
 		err := svc.Prune(context.Background(), PruneInput{Base: "main", OutputDir: outputDir})
 		if err != nil {
@@ -502,7 +514,7 @@ func TestServicePrune(t *testing.T) {
 			{output: twoPorcelain},
 			{output: []byte("")}, // nothing merged
 		}}
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard)
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
 
 		err := svc.Prune(context.Background(), PruneInput{Base: "main", OutputDir: outputDir})
 		if err != nil {
@@ -520,7 +532,7 @@ func TestServicePrune(t *testing.T) {
 			{},                                // git worktree remove (other)
 			{},                                // git branch -d (other)
 		}}
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard)
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
 
 		// cwd is inside featPath — feat should be skipped, other should be removed
 		err := svc.Prune(context.Background(), PruneInput{
@@ -544,7 +556,7 @@ func TestServicePrune(t *testing.T) {
 			{},                                   // git worktree remove other
 			{},                                   // git branch -d other
 		}}
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard)
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
 
 		err := svc.Prune(context.Background(), PruneInput{Base: "main", OutputDir: outputDir})
 		if err == nil {
@@ -581,13 +593,124 @@ func TestServicePrune(t *testing.T) {
 	}
 	for _, tt := range errorTests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := NewService(tt.runner, &fakeSyncer{}, &fakeOpener{}, io.Discard)
+			svc := NewService(tt.runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
 			err := svc.Prune(context.Background(), PruneInput{Base: "main", OutputDir: outputDir})
 			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 				t.Errorf("got error %v, want error containing %q", err, tt.wantErr)
 			}
 		})
 	}
+
+	t.Run("--all errors when not on main worktree", func(t *testing.T) {
+		runner := &seqRunner{responses: []runResponse{
+			{output: twoPorcelain}, // git worktree list
+		}}
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
+
+		err := svc.Prune(context.Background(), PruneInput{
+			All:       true,
+			OutputDir: outputDir,
+			Cwd:       featPath, // not the main worktree
+		})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "--all must be run from the main worktree") {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if runner.idx != 1 {
+			t.Errorf("runner called %d times, want 1 (list only)", runner.idx)
+		}
+	})
+
+	t.Run("--all dry-run lists all non-main worktrees without removing", func(t *testing.T) {
+		runner := &seqRunner{responses: []runResponse{
+			{output: threePorcelain}, // git worktree list
+		}}
+		var buf strings.Builder
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
+
+		err := svc.Prune(context.Background(), PruneInput{
+			All:       true,
+			DryRun:    true,
+			OutputDir: outputDir,
+			Cwd:       mainPath,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if runner.idx != 1 {
+			t.Errorf("runner called %d times, want 1 (list only, no merged check)", runner.idx)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "would remove: feat") {
+			t.Errorf("output missing feat worktree; got:\n%s", out)
+		}
+		if !strings.Contains(out, "would remove: other") {
+			t.Errorf("output missing other worktree; got:\n%s", out)
+		}
+	})
+
+	t.Run("--all aborts on negative confirmation", func(t *testing.T) {
+		runner := &seqRunner{responses: []runResponse{
+			{output: twoPorcelain}, // git worktree list
+		}}
+		var buf strings.Builder
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader("n\n"))
+
+		err := svc.Prune(context.Background(), PruneInput{
+			All:       true,
+			OutputDir: outputDir,
+			Cwd:       mainPath,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if runner.idx != 1 {
+			t.Errorf("runner called %d times after abort, want 1 (list only)", runner.idx)
+		}
+		if !strings.Contains(buf.String(), "aborted") {
+			t.Errorf("output should contain 'aborted'; got:\n%s", buf.String())
+		}
+	})
+
+	t.Run("--all force-removes on yes", func(t *testing.T) {
+		wsFile := filepath.Join(outputDir, repoSlug+"-feat.code-workspace")
+		if err := os.WriteFile(wsFile, []byte("{}"), 0o644); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+
+		rec := &recordingRunner{inner: &seqRunner{responses: []runResponse{
+			{output: twoPorcelain}, // git worktree list
+			{},                     // git worktree remove --force
+			{},                     // git branch -D
+		}}}
+		svc := NewService(rec, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader("y\n"))
+
+		err := svc.Prune(context.Background(), PruneInput{
+			All:       true,
+			OutputDir: outputDir,
+			Cwd:       mainPath,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rec.inner.idx != 3 {
+			t.Errorf("runner called %d times, want 3", rec.inner.idx)
+		}
+		// Verify --force flag was passed to git worktree remove.
+		if len(rec.calls) < 2 || rec.calls[1][3] != "--force" {
+			t.Errorf("expected 'git worktree remove --force ...', got calls: %v", rec.calls)
+		}
+		// Verify -D flag was passed to git branch.
+		if len(rec.calls) < 3 || rec.calls[2][2] != "-D" {
+			t.Errorf("expected 'git branch -D ...', got calls: %v", rec.calls)
+		}
+		// Artifact file should have been deleted.
+		if _, statErr := os.Stat(wsFile); !os.IsNotExist(statErr) {
+			t.Error("artifact file should have been deleted")
+		}
+	})
 }
 
 func TestServiceStatus(t *testing.T) {
@@ -626,7 +749,7 @@ func TestServiceStatus(t *testing.T) {
 		}}
 
 		var buf strings.Builder
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf)
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
 		err := svc.Status(context.Background(), StatusInput{OutputDir: outputDir})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -653,7 +776,7 @@ func TestServiceStatus(t *testing.T) {
 			{output: commitOutput("def5678", "add x")},
 		}}
 		var buf strings.Builder
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf)
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
 		err := svc.Status(context.Background(), StatusInput{JSON: true, OutputDir: outputDir})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -702,7 +825,7 @@ func TestServiceStatus(t *testing.T) {
 	}
 	for _, tt := range errorTests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := NewService(tt.runner, &fakeSyncer{}, &fakeOpener{}, io.Discard)
+			svc := NewService(tt.runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
 			err := svc.Status(context.Background(), StatusInput{OutputDir: outputDir})
 			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 				t.Errorf("got error %v, want error containing %q", err, tt.wantErr)


### PR DESCRIPTION
## Summary

- Adds `--all` flag to `treepad prune` that force-removes every non-main worktree regardless of merge status
- Guards: errors if not invoked from the main worktree; lists candidates and prompts `continue? [y/N]` before acting
- Uses `git worktree remove --force` + `git branch -D`; `--dry-run` still works alongside `--all`
- Injects `io.Reader` into `Service` to support the confirmation prompt (all command call-sites pass `os.Stdin`)

## Test plan

- [ ] `--all` from a non-main worktree returns an error naming the main path
- [ ] `--all --dry-run` lists all non-main worktrees without prompting or removing
- [ ] `--all` with input `n` prints "aborted" and leaves worktrees intact
- [ ] `--all` with input `y` force-removes all non-main worktrees, deletes branches, and cleans artifact files
- [ ] Existing `prune` (no flag) behaviour unchanged — all prior tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)