### PR TITLE
feat: rename CLI binary from treepad to tp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - run: go build -o treepad ./cmd/treepad
+      - run: go build -o tp ./cmd/tp
 
   tidy:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .claude/agents
 ideas/
 dist
+tp

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,9 +5,9 @@ before:
     - go mod tidy
 
 builds:
-  - id: treepad
-    main: ./cmd/treepad
-    binary: treepad
+  - id: tp
+    main: ./cmd/tp
+    binary: tp
     env:
       - CGO_ENABLED=0
     goos:
@@ -44,13 +44,13 @@ changelog:
 homebrew_casks:
   - name: treepad
     binaries:
-      - treepad
+      - tp
     homepage: "https://github.com/O-Marsters-1997/treepad"
     description: "CLI for managing git worktrees"
     hooks:
       post:
         install: |
-          system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/treepad"]
+          system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/tp"]
     url:
       template: "https://github.com/O-Marsters-1997/treepad/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
       verified: "github.com/O-Marsters-1997/treepad/"

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -4,7 +4,7 @@ This document describes the architecture and module organization.
 
 ## Entry Point
 
-**`cmd/workspace/main.go`** — CLI bootstrap
+**`cmd/tp/main.go`** — CLI bootstrap
 
 - Initializes the `urfave/cli` v3 application with the verbose flag
 - Calls `commands.Router()` to get all available CLI commands
@@ -39,8 +39,8 @@ Central location for all CLI command definitions. Separates CLI wiring from busi
 
 ### `shell_init.go`
 
-- `shellInitCommand()` — prints shell wrapper function for `eval "$(treepad shell-init)"`
-  - Wrapper intercepts `__TREEPAD_CD__` directive from `treepad new` and cd's into the new worktree
+- `shellInitCommand()` — prints shell wrapper function for `eval "$(tp shell-init)"`
+  - Wrapper intercepts `__TREEPAD_CD__` directive from `tp new` and cd's into the new worktree
 
 ### `remove.go`
 
@@ -63,11 +63,11 @@ Central location for all CLI command definitions. Separates CLI wiring from busi
 ### `config.go`
 
 - `configCommand()` — top-level config command group
-- `configInitCommand()` — `treepad config init` subcommand
+- `configInitCommand()` — `tp config init` subcommand
   - Flag: `--global` (write to global config path instead of repo root)
   - Resolves worktrees and main worktree path
   - Calls `config.WriteDefault(dir, global bool)` which writes annotated `.treepad.toml`
-- `configShowCommand()` — `treepad config show` subcommand
+- `configShowCommand()` — `tp config show` subcommand
   - Resolves worktrees and main worktree path
   - Calls `config.Show(repoRoot)` to display resolved config and sources
 
@@ -229,7 +229,7 @@ Utility for deriving short identifiers from repository paths.
 ## CLI Command Structure
 
 ```
-treepad [--verbose] <command>
+tp [--verbose] <command>
 ├── workspace [options] [source-path]
 │   ├── --use-current (-c)
 │   ├── --sync-only
@@ -269,43 +269,43 @@ treepad [--verbose] <command>
 
 6. **Editor Agnosticism** — No editor names in Go code. Artifact filename, content, and open command are all text/template strings in `.treepad.toml`. VS Code is the default (baked into defaults). Other editors configure via config only.
 
-## Data Flow Example: `treepad workspace`
+## Data Flow Example: `tp workspace`
 
-1. `main.go` parses flags and calls `commands.Router()`
+1. `cmd/tp/main.go` parses flags and calls `commands.Router()`
 2. `commands.workspaceCommand()` defines CLI interface
 3. `runWorkspace()` parses args, instantiates `treepad.Service`, calls `Generate()`
 4. `Service.Generate()` resolves source, loads config via `config.Load()`, syncs files via `sync.FileSyncer`
 5. Optionally generates artifact files via `artifact.Write()`
 
-## Data Flow Example: `treepad new`
+## Data Flow Example: `tp new`
 
-1. `main.go` parses flags and calls `commands.Router()`
+1. `cmd/tp/main.go` parses flags and calls `commands.Router()`
 2. `commands.newCommand()` defines CLI interface
 3. `runNew()` parses args, instantiates `treepad.Service`, calls `New()`
 4. `Service.New()` runs `git worktree add`, syncs configs, generates artifact file
 5. Optionally opens artifact file via `artifact.ExecOpener`
 6. Unless `--current` / `-c` is passed, emits `__TREEPAD_CD__\t<path>` to stdout
-7. Shell wrapper (from `treepad shell-init`) intercepts the directive and cd's into the new worktree
+7. Shell wrapper (from `tp shell-init`) intercepts the directive and cd's into the new worktree
 
-## Data Flow Example: `treepad config init --global`
+## Data Flow Example: `tp config init --global`
 
-1. `main.go` initializes CLI
+1. `cmd/tp/main.go` initializes CLI
 2. `commands.config.configInitCommand()` handles the action
 3. If `--global` flag is set, calls `config.WriteDefault("", true)`
 4. Otherwise, lists worktrees via `worktree.List()`, gets main worktree, calls `config.WriteDefault(mainPath, false)`
 5. File is written to global or local path
 
-## Data Flow Example: `treepad config show`
+## Data Flow Example: `tp config show`
 
-1. `main.go` initializes CLI
+1. `cmd/tp/main.go` initializes CLI
 2. `commands.config.configShowCommand()` handles the action
 3. Lists worktrees via `worktree.List()`, gets main worktree path
 4. Calls `config.Show(mainPath)`
 5. `Show()` checks local, global, and defaults; returns formatted summary with sources
 
-## Data Flow Example: `treepad remove <branch>`
+## Data Flow Example: `tp remove <branch>`
 
-1. `main.go` parses flags and calls `commands.Router()`
+1. `cmd/tp/main.go` parses flags and calls `commands.Router()`
 2. `commands.removeCommand()` defines CLI interface
 3. `runRemove()` parses branch argument, instantiates `treepad.Service`, calls `Remove()`
 4. `Service.Remove()` executes three steps:
@@ -315,9 +315,9 @@ treepad [--verbose] <command>
    - Deletes artifact file from output directory (missing file is not an error)
    - Deletes branch locally via `git branch -d`
 
-## Data Flow Example: `treepad prune [--base main] [--dry-run] [--all]`
+## Data Flow Example: `tp prune [--base main] [--dry-run] [--all]`
 
-1. `main.go` parses flags and calls `commands.Router()`
+1. `cmd/tp/main.go` parses flags and calls `commands.Router()`
 2. `commands.pruneCommand()` defines CLI interface
 3. `runPrune()` parses flags, instantiates `treepad.Service`, calls `Prune()`
 4. `Service.Prune()` dispatches based on `All` flag:
@@ -335,9 +335,9 @@ treepad [--verbose] <command>
      - Otherwise removes each candidate via `removeWorktree()` (safe removal via git worktree remove, git branch -d)
    - Returns error if any removals failed
 
-## Data Flow Example: `treepad status [--json]`
+## Data Flow Example: `tp status [--json]`
 
-1. `main.go` parses flags and calls `commands.Router()`
+1. `cmd/tp/main.go` parses flags and calls `commands.Router()`
 2. `commands.statusCommand()` defines CLI interface
 3. `runStatus()` parses flags, instantiates `treepad.Service`, calls `Status()`
 4. `Service.Status()` executes:

--- a/Justfile
+++ b/Justfile
@@ -2,10 +2,10 @@ default:
     @just --list
 
 build:
-    go build -o treepad ./cmd/treepad
+    go build -o tp ./cmd/tp
 
 run *args:
-    go run ./cmd/treepad/main.go {{args}}
+    go run ./cmd/tp/main.go {{args}}
 
 test:
     go test ./...
@@ -26,7 +26,7 @@ tidy:
     go mod tidy
 
 clean:
-    rm -f treepad
+    rm -f tp
 
 ci:
     golangci-lint run ./...

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# treepad
+# tp
 
 A CLI for managing git worktrees — providing a standardised, extensible set of utilities for working with worktrees.
 
 ## Overview
 
-`treepad` makes it easy to create, navigate, and manage git worktrees from the command line. The aim is to build a consistent, composable toolset around worktree workflows that can be extended as new patterns emerge.
+`tp` makes it easy to create, navigate, and manage git worktrees from the command line. The aim is to build a consistent, composable toolset around worktree workflows that can be extended as new patterns emerge.
 
-A primary motivation is **parallelising [Claude Code](https://claude.ai/code) instances**: each worktree gets its own isolated working directory, allowing multiple AI coding sessions to run simultaneously on different tasks without interfering with each other. `treepad` provides the primitives to spin up, coordinate, and share context between those worktrees.
+A primary motivation is **parallelising [Claude Code](https://claude.ai/code) instances**: each worktree gets its own isolated working directory, allowing multiple AI coding sessions to run simultaneously on different tasks without interfering with each other. `tp` provides the primitives to spin up, coordinate, and share context between those worktrees.
 
 ## Built with
 
@@ -24,8 +24,10 @@ brew install O-Marsters-1997/tap/treepad
 ### go install
 
 ```bash
-go install github.com/O-Marsters-1997/treepad/cmd/treepad@latest
+go install github.com/O-Marsters-1997/treepad/cmd/tp@latest
 ```
+
+This installs the `tp` binary.
 
 ### From source
 
@@ -35,26 +37,26 @@ cd treepad
 just build
 ```
 
-This produces a `treepad` binary in the project root. Move it somewhere on your `$PATH`.
+This produces a `tp` binary in the project root. Move it somewhere on your `$PATH`.
 
 ### After installing
 
-Initialise a config file in your repo (optional — treepad works with zero config):
+Initialise a config file in your repo (optional — tp works with zero config):
 
 ```bash
-treepad config init
+tp config init
 ```
 
-Run `treepad config show` to confirm which config is active.
+Run `tp config show` to confirm which config is active.
 
 ## Configuration
 
-`treepad` works with zero configuration. See [docs/configuration.md](docs/configuration.md) for more info on how to configure it and what the defaults are.
+`tp` works with zero configuration. See [docs/configuration.md](docs/configuration.md) for more info on how to configure it and what the defaults are.
 
 ## Usage
 
 ```
-treepad [--verbose | -v] <command> [options]
+tp [--verbose | -v] <command> [options]
 ```
 
 ### Main commands
@@ -63,41 +65,41 @@ treepad [--verbose | -v] <command> [options]
 
 ```bash
 # Sync configs and generate artifact files from the main worktree
-treepad workspace
+tp workspace
 
 # Sync only — skip artifact file generation
-treepad workspace --sync-only
+tp workspace --sync-only
 
 # Use the current directory as the config source instead of the main worktree
-treepad workspace --use-current
+tp workspace --use-current
 
 # Include extra file patterns in the sync
-treepad workspace --include ".prettierrc" --include ".eslintrc.json"
+tp workspace --include ".prettierrc" --include ".eslintrc.json"
 
-# Debug what treepad is doing
-treepad --verbose workspace
+# Debug what tp is doing
+tp --verbose workspace
 ```
 
 **`new`** — Create a new git worktree with configs synced and artifact file generated:
 
 ```bash
 # Create a new worktree for branch 'feature-x' branched from main (cd's into it automatically)
-treepad new feature-x
+tp new feature-x
 
 # Create a worktree from a different base ref
-treepad new bugfix-y --base develop
+tp new bugfix-y --base develop
 
 # Create a worktree and open the artifact file
-treepad new feature-z --open
+tp new feature-z --open
 
 # Stay in the current directory instead of cd-ing into the new worktree
-treepad new feature-z -c
+tp new feature-z -c
 ```
 
-> **Shell integration:** `treepad new` prints a cd directive that is acted on by a shell wrapper function. Add the following to your `~/.zshrc` or `~/.bashrc`:
+> **Shell integration:** `tp new` prints a cd directive that is acted on by a shell wrapper function. Add the following to your `~/.zshrc` or `~/.bashrc`:
 >
 > ```sh
-> eval "$(treepad shell-init)"
+> eval "$(tp shell-init)"
 > ```
 
 **`remove`** — Remove a git worktree and its associated files:
@@ -105,55 +107,55 @@ treepad new feature-z -c
 ```bash
 # Remove a completed feature branch (switch out of it first)
 cd ../main-repo
-treepad remove feature-x
+tp remove feature-x
 ```
 
 **`prune`** — Remove all worktrees whose branches are merged into a base branch, or force-remove all non-main worktrees:
 
 ```bash
 # Remove all worktrees whose branches are merged into main
-treepad prune
+tp prune
 
 # Preview without executing
-treepad prune --dry-run
+tp prune --dry-run
 
 # Check merges against a different base branch
-treepad prune --base develop
+tp prune --base develop
 
 # Force-remove all non-main worktrees (with confirmation)
-treepad prune --all
+tp prune --all
 ```
 
 **`cd`** — cd into an existing worktree by branch name:
 
 ```bash
 # cd into an existing worktree (shell integration handles the directory change)
-treepad cd feature-x
+tp cd feature-x
 ```
 
-> Requires `eval "$(treepad shell-init)"` in your shell rc — the same wrapper used by `new`.
+> Requires `eval "$(tp shell-init)"` in your shell rc — the same wrapper used by `new`.
 
 **`status`** — List all worktrees with their branch, dirty state, ahead/behind count, and last commit:
 
 ```bash
 # Show status of all worktrees in a table
-treepad status
+tp status
 
 # Emit JSON for scripting or dashboards
-treepad status --json
+tp status --json
 ```
 
-**`config`** — Manage treepad configuration:
+**`config`** — Manage tp configuration:
 
 ```bash
 # Write a default .treepad.toml to the main worktree root
-treepad config init
+tp config init
 
 # Write config to the global config path
-treepad config init --global
+tp config init --global
 
 # Show the resolved config and which source(s) contributed
-treepad config show
+tp config show
 ```
 
 See [docs/commands.md](docs/commands.md) for the full command reference.

--- a/cmd/tp/main.go
+++ b/cmd/tp/main.go
@@ -19,7 +19,7 @@ var (
 
 func main() {
 	cmd := &cli.Command{
-		Name:    "treepad",
+		Name:    "tp",
 		Usage:   "CLI for managing git worktrees",
 		Version: version + " (commit: " + commit + ", built: " + date + ")",
 		Flags: []cli.Flag{

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -5,7 +5,7 @@
 Syncs editor configs and generates artifact files across all git worktrees. By default, generates VS Code `.code-workspace` files.
 
 ```
-treepad workspace [options] [source-path]
+tp workspace [options] [source-path]
 ```
 
 By default, uses the main worktree (the one with a `.git` directory) as the config source. Configs from `.vscode/`, `.claude/`, and `.env` files are copied to every other worktree. The artifact file generated is controlled by `.treepad.toml` and can be customized for any editor.
@@ -28,22 +28,22 @@ By default, uses the main worktree (the one with a `.git` directory) as the conf
 
 ```bash
 # Generate artifact files and sync configs from the main worktree
-treepad workspace
+tp workspace
 
 # Sync configs only (no artifact files generated)
-treepad workspace --sync-only
+tp workspace --sync-only
 
 # Use the current directory as the config source
-treepad workspace --use-current
+tp workspace --use-current
 
 # Write artifact files to a custom directory
-treepad workspace --output-dir ~/my-workspaces
+tp workspace --output-dir ~/my-workspaces
 
 # Use an explicit repo path as the config source
-treepad workspace /path/to/repo
+tp workspace /path/to/repo
 
 # Include extra file patterns in the sync
-treepad workspace --include ".prettierrc" --include "*.md"
+tp workspace --include ".prettierrc" --include "*.md"
 ```
 
 ### Configuration
@@ -55,7 +55,7 @@ See [configuration.md](configuration.md) for the full schema, defaults, and exam
 Create a new git worktree, sync configs from the main worktree, and generate an artifact file for it.
 
 ```
-treepad new [options] <branch>
+tp new [options] <branch>
 ```
 
 Creates a new worktree branched from a specified ref (default: `main`), syncs editor configs from the main worktree, and generates an artifact file as configured in `.treepad.toml`. By default, cd's into the new worktree directory when invoked via the shell wrapper (see [Shell integration](#shell-integration) below).
@@ -72,16 +72,16 @@ Creates a new worktree branched from a specified ref (default: `main`), syncs ed
 
 ```bash
 # Create a new worktree for branch 'feature-x' branched from main
-treepad new feature-x
+tp new feature-x
 
 # Create a worktree from a different base ref
-treepad new bugfix-y --base develop
+tp new bugfix-y --base develop
 
 # Create a worktree and open the generated artifact file
-treepad new feature-z --open
+tp new feature-z --open
 
 # Stay in the current directory instead of cd-ing in
-treepad new my-branch -c
+tp new my-branch -c
 ```
 
 ## cd
@@ -89,58 +89,58 @@ treepad new my-branch -c
 cd into an existing worktree by branch name.
 
 ```
-treepad cd <branch>
+tp cd <branch>
 ```
 
 Looks up the worktree registered under `<branch>` from `git worktree list` and emits a `__TREEPAD_CD__` directive. The shell wrapper installed by `shell-init` intercepts it and changes the current directory. No flags — positional branch argument only.
 
-If the branch has no associated worktree, an error is returned with a suggestion to use `treepad new <branch>`.
+If the branch has no associated worktree, an error is returned with a suggestion to use `tp new <branch>`.
 
 ### Setup
 
 Requires the shell wrapper (same as `new`):
 
 ```sh
-eval "$(treepad shell-init)"
+eval "$(tp shell-init)"
 ```
 
 ### Examples
 
 ```bash
 # cd into an existing worktree
-treepad cd feature-x
+tp cd feature-x
 
 # Run the binary directly to inspect the directive
-command treepad cd feature-x
+command tp cd feature-x
 # => __TREEPAD_CD__	/path/to/repo-feature-x
 ```
 
 ## shell-init
 
-Print a shell wrapper function that enables `treepad new` to cd into the new worktree automatically.
+Print a shell wrapper function that enables `tp new` to cd into the new worktree automatically.
 
 ```
-treepad shell-init
+tp shell-init
 ```
 
-Because a child process cannot change the parent shell's working directory, `treepad new` emits a `__TREEPAD_CD__` directive in its output. The shell wrapper function intercepts this directive, strips it from the visible output, and cd's into the path.
+Because a child process cannot change the parent shell's working directory, `tp new` emits a `__TREEPAD_CD__` directive in its output. The shell wrapper function intercepts this directive, strips it from the visible output, and cd's into the path.
 
 ### Setup
 
 Add to your `~/.zshrc` or `~/.bashrc`:
 
 ```sh
-eval "$(treepad shell-init)"
+eval "$(tp shell-init)"
 ```
 
-After sourcing, `treepad new <branch>` will automatically cd into the new worktree. Pass `-c` / `--current` to skip the cd.
+After sourcing, `tp new <branch>` will automatically cd into the new worktree. Pass `-c` / `--current` to skip the cd.
 
 ## config
 
-Manage treepad configuration files.
+Manage tp configuration files.
 
 ```
-treepad config <subcommand>
+tp config <subcommand>
 ```
 
 ### config init
@@ -148,7 +148,7 @@ treepad config <subcommand>
 Write a config file with default values.
 
 ```
-treepad config init [--global]
+tp config init [--global]
 ```
 
 By default, writes `.treepad.toml` to the main worktree root (the directory containing `.git`). Use the `--global` flag to write to the global config path instead.
@@ -163,10 +163,10 @@ By default, writes `.treepad.toml` to the main worktree root (the directory cont
 
 ```bash
 # Write default config to the main worktree root
-treepad config init
+tp config init
 
 # Write default config to the global config path
-treepad config init --global
+tp config init --global
 ```
 
 ### config show
@@ -174,7 +174,7 @@ treepad config init --global
 Print the resolved config and which sources contributed.
 
 ```
-treepad config show
+tp config show
 ```
 
 Displays the final configuration that would be used, along with information about which source(s) contributed to it. Resolution order is:
@@ -186,7 +186,7 @@ Displays the final configuration that would be used, along with information abou
 
 ```bash
 # Show the resolved config and its sources
-treepad config show
+tp config show
 ```
 
 This will output something like:
@@ -211,7 +211,7 @@ See [configuration.md](configuration.md) for details on the configuration schema
 Remove a git worktree, delete its artifact file, and delete the local branch.
 
 ```
-treepad remove <branch>
+tp remove <branch>
 ```
 
 Removes the worktree for the specified branch, cleans up its associated artifact file (if any), and deletes the branch locally. Includes pre-flight safety guards to prevent accidental data loss.
@@ -225,11 +225,11 @@ Removes the worktree for the specified branch, cleans up its associated artifact
 
 ```bash
 # Remove a completed feature branch
-treepad remove feature-x
+tp remove feature-x
 
 # Remove after switching out of the worktree
 cd ../main-repo  # or any other location
-treepad remove feature-x
+tp remove feature-x
 ```
 
 ### Errors
@@ -246,7 +246,7 @@ cannot remove the worktree you are currently in; cd elsewhere first
 Remove all worktrees whose branches are already merged into a base branch, or force-remove all non-main worktrees. Useful for batch-cleaning completed work.
 
 ```
-treepad prune [options]
+tp prune [options]
 ```
 
 Automatically identifies and removes worktrees whose branches have been merged into a base branch (default: `main`). Executes removals directly; pass `--dry-run` to preview without making changes. Use `--all` to force-remove all non-main worktrees (with confirmation prompt).
@@ -276,22 +276,22 @@ When using `--all`:
 
 ```bash
 # Remove all worktrees merged into main
-treepad prune
+tp prune
 
 # Preview without executing
-treepad prune --dry-run
+tp prune --dry-run
 
 # Check merges against a different base branch
-treepad prune --base develop
+tp prune --base develop
 
 # Preview against a different base
-treepad prune --base develop --dry-run
+tp prune --base develop --dry-run
 
 # Force-remove all non-main worktrees (with confirmation)
-treepad prune --all
+tp prune --all
 
 # Preview force-removal without executing
-treepad prune --all --dry-run
+tp prune --all --dry-run
 ```
 
 ### Output Examples
@@ -361,7 +361,7 @@ deleted branch: feature-y
 List all worktrees in the repo with their branch, dirty state, ahead/behind count vs upstream, last commit, and last-touched time (from artifact file mtime).
 
 ```
-treepad status [options]
+tp status [options]
 ```
 
 Provides a repo-wide snapshot of all active worktrees, showing which ones have uncommitted changes, how they diverge from their upstream branches, and when they were last modified by agents or editors.
@@ -387,14 +387,14 @@ Provides a repo-wide snapshot of all active worktrees, showing which ones have u
 
 ```bash
 # Show status of all worktrees in a table
-treepad status
+tp status
 
 # Emit JSON for scripting or dashboards
-treepad status --json
+tp status --json
 
 # Combine with standard tools
-treepad status | grep dirty
-treepad status --json | jq '.[] | select(.dirty == true)'
+tp status | grep dirty
+tp status --json | jq '.[] | select(.dirty == true)'
 ```
 
 ### Output Examples

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-`treepad` works with zero configuration. To customize behavior, add a `.treepad.toml` file to your repo root or write a global config file.
+`tp` works with zero configuration. To customize behavior, add a `.treepad.toml` file to your repo root or write a global config file.
 
 ## Configuration Format
 
@@ -68,7 +68,7 @@ content = """{
 
 ### `[open]` section
 
-Command to run when `treepad new --open` is used. Each element is a Go text/template string evaluated against the open context.
+Command to run when `tp new --open` is used. Each element is a Go text/template string evaluated against the open context.
 
 | Field     | Type     | Description                                                    |
 | --------- | -------- | -------------------------------------------------------------- |
@@ -115,7 +115,7 @@ Configuration is resolved in the following order (first match wins):
    - `~/.config/treepad/config.toml` (fallback)
 3. **Built-in defaults** — used when no config files are present
 
-Use `treepad config show` to see which configuration source is being used.
+Use `tp config show` to see which configuration source is being used.
 
 ## Example Configurations
 
@@ -153,7 +153,7 @@ content = """
 command = ["open", "{{.ArtifactPath}}"]
 ```
 
-Run `treepad config init` to write this configuration.
+Run `tp config init` to write this configuration.
 
 ### JetBrains IDEs (IntelliJ IDEA, GoLand, WebStorm, etc.)
 

--- a/internal/commands/shell_init.go
+++ b/internal/commands/shell_init.go
@@ -7,12 +7,12 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-// shellFunc is the shell wrapper function users source via `eval "$(treepad shell-init)"`.
-// It captures all output from the real treepad binary, extracts the __TREEPAD_CD__ directive
-// emitted by `treepad new`, cd's into that path, then prints the remaining output.
-const shellFunc = `treepad() {
+// shellFunc is the shell wrapper function users source via `eval "$(tp shell-init)"`.
+// It captures all output from the real tp binary, extracts the __TREEPAD_CD__ directive
+// emitted by `tp new`, cd's into that path, then prints the remaining output.
+const shellFunc = `tp() {
   local out rc cd_path
-  out=$(command treepad "$@")
+  out=$(command tp "$@")
   rc=$?
   cd_path=$(printf '%s\n' "$out" | awk -F'\t' '/^__TREEPAD_CD__\t/ {print $2; exit}')
   printf '%s\n' "$out" | grep -v '^__TREEPAD_CD__	' || true
@@ -23,7 +23,7 @@ const shellFunc = `treepad() {
 func shellInitCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "shell-init",
-		Usage: "print shell integration function; add `eval \"$(treepad shell-init)\"` to your shell rc file",
+		Usage: "print shell integration function; add `eval \"$(tp shell-init)\"` to your shell rc file",
 		Action: func(_ context.Context, cmd *cli.Command) error {
 			_, err := io.WriteString(cmd.Root().Writer, shellFunc+"\n")
 			return err

--- a/internal/commands/shell_init_test.go
+++ b/internal/commands/shell_init_test.go
@@ -24,7 +24,7 @@ func TestShellInitCommand(t *testing.T) {
 	}
 
 	out := buf.String()
-	for _, want := range []string{"treepad()", "__TREEPAD_CD__"} {
+	for _, want := range []string{"tp()", "__TREEPAD_CD__"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("shell-init output missing %q; got:\n%s", want, out)
 		}


### PR DESCRIPTION
## Summary

- Renames the CLI binary from `treepad` to `tp` across the entire project
- Entrypoint moved from `cmd/treepad/` to `cmd/tp/`, with `Name: "tp"` so help text reflects the new name
- Shell wrapper function renamed from `treepad()` to `tp()` in `shell-init` output
- Build, release, and CI configs updated (`Justfile`, `.goreleaser.yml`, `.github/workflows/ci.yml`)
- All docs updated (`README.md`, `docs/commands.md`, `docs/configuration.md`, `CODEMAP.md`)

## Test plan

- [ ] `just build` produces a `tp` binary
- [ ] `./tp --help` shows `NAME: tp`
- [ ] `./tp shell-init` defines `tp()` with `command tp "$@"`
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)