### PR TITLE
feat: add treepad doctor command

### DIFF
--- a/internal/commands/doctor.go
+++ b/internal/commands/doctor.go
@@ -1,0 +1,46 @@
+package commands
+
+import (
+	"context"
+	"os"
+
+	"github.com/urfave/cli/v3"
+
+	"treepad/internal/artifact"
+	internalsync "treepad/internal/sync"
+	"treepad/internal/treepad"
+	"treepad/internal/worktree"
+)
+
+func doctorCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "doctor",
+		Usage: "report cross-worktree health issues (stale, merged-present, remote-gone, config-drift)",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{Name: "json", Usage: "emit JSON instead of a table"},
+			&cli.IntFlag{Name: "stale-days", Value: 30, Usage: "flag worktrees with no commit in this many days"},
+			&cli.StringFlag{Name: "base", Value: "main", Usage: "branch to check merges against"},
+			&cli.BoolFlag{Name: "offline", Usage: "skip remote branch existence check"},
+			&cli.BoolFlag{Name: "strict", Usage: "exit non-zero if any findings are reported"},
+		},
+		Action: runDoctor,
+	}
+}
+
+func runDoctor(ctx context.Context, cmd *cli.Command) error {
+	runner := worktree.ExecRunner{}
+	svc := treepad.NewService(
+		runner,
+		internalsync.FileSyncer{},
+		artifact.ExecOpener{Runner: runner},
+		os.Stdout,
+		os.Stdin,
+	)
+	return svc.Doctor(ctx, treepad.DoctorInput{
+		JSON:      cmd.Bool("json"),
+		StaleDays: int(cmd.Int("stale-days")),
+		Base:      cmd.String("base"),
+		Offline:   cmd.Bool("offline"),
+		Strict:    cmd.Bool("strict"),
+	})
+}

--- a/internal/commands/router.go
+++ b/internal/commands/router.go
@@ -12,5 +12,6 @@ func Router() []*cli.Command {
 		pruneCommand(),
 		statusCommand(),
 		cdCommand(),
+		doctorCommand(),
 	}
 }

--- a/internal/treepad/service_doctor.go
+++ b/internal/treepad/service_doctor.go
@@ -1,0 +1,204 @@
+package treepad
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"treepad/internal/artifact"
+	"treepad/internal/config"
+	"treepad/internal/slug"
+	"treepad/internal/worktree"
+)
+
+type DoctorInput struct {
+	JSON      bool
+	StaleDays int
+	Base      string
+	Offline   bool
+	Strict    bool
+	OutputDir string
+}
+
+type DoctorFinding struct {
+	Branch string `json:"branch"`
+	Path   string `json:"path"`
+	Kind   string `json:"kind"`
+	Detail string `json:"detail"`
+}
+
+func (s *Service) Doctor(ctx context.Context, in DoctorInput) error {
+	worktrees, err := s.listWorktrees(ctx)
+	if err != nil {
+		return err
+	}
+
+	mainWT, err := worktree.MainWorktree(worktrees)
+	if err != nil {
+		return err
+	}
+
+	repoSlug := slug.Slug(filepath.Base(mainWT.Path))
+
+	outputDir, err := s.resolveOutputDir(in.OutputDir, repoSlug)
+	if err != nil {
+		return err
+	}
+
+	mainCfg, err := config.Load(mainWT.Path)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	spec := artifactSpec(mainCfg.Artifact)
+
+	mergedBranches, err := worktree.MergedBranches(ctx, s.runner, in.Base)
+	if err != nil {
+		return fmt.Errorf("merged branches: %w", err)
+	}
+	mergedSet := make(map[string]bool, len(mergedBranches))
+	for _, b := range mergedBranches {
+		mergedSet[b] = true
+	}
+
+	staleThreshold := time.Duration(in.StaleDays) * 24 * time.Hour
+
+	var findings []DoctorFinding
+
+	for _, wt := range worktrees {
+		if wt.Branch == "(detached)" {
+			continue
+		}
+
+		commit, err := worktree.LastCommit(ctx, s.runner, wt.Path)
+		if err != nil {
+			return err
+		}
+
+		dirty, err := worktree.Dirty(ctx, s.runner, wt.Path)
+		if err != nil {
+			return err
+		}
+
+		if commit.ShortSHA != "" {
+			age := time.Since(commit.Committed)
+			if dirty && age > staleThreshold {
+				findings = append(findings, DoctorFinding{
+					Branch: wt.Branch,
+					Path:   wt.Path,
+					Kind:   "dirty-old",
+					Detail: fmt.Sprintf("uncommitted changes, last commit %s ago", since(commit.Committed)),
+				})
+			} else if age > staleThreshold {
+				findings = append(findings, DoctorFinding{
+					Branch: wt.Branch,
+					Path:   wt.Path,
+					Kind:   "stale",
+					Detail: fmt.Sprintf("last commit %s ago", since(commit.Committed)),
+				})
+			}
+		}
+
+		if !wt.IsMain && mergedSet[wt.Branch] {
+			findings = append(findings, DoctorFinding{
+				Branch: wt.Branch,
+				Path:   wt.Path,
+				Kind:   "merged-present",
+				Detail: fmt.Sprintf("branch already merged into %s", in.Base),
+			})
+		}
+
+		if !in.Offline {
+			exists, hasUpstream, err := worktree.RemoteBranchExists(ctx, s.runner, wt.Path, wt.Branch)
+			if err != nil {
+				return err
+			}
+			if hasUpstream && !exists {
+				findings = append(findings, DoctorFinding{
+					Branch: wt.Branch,
+					Path:   wt.Path,
+					Kind:   "remote-gone",
+					Detail: "branch no longer exists on remote",
+				})
+			}
+		}
+
+		data := s.templateData(repoSlug, wt.Branch, wt.Path, outputDir)
+		artifactPath, ok, err := artifact.Path(spec, outputDir, data)
+		if err != nil {
+			return fmt.Errorf("resolve artifact path: %w", err)
+		}
+		if ok {
+			if _, statErr := os.Stat(artifactPath); os.IsNotExist(statErr) {
+				findings = append(findings, DoctorFinding{
+					Branch: wt.Branch,
+					Path:   wt.Path,
+					Kind:   "artifact-missing",
+					Detail: fmt.Sprintf("expected artifact at %s", collapsePath(artifactPath)),
+				})
+			}
+		}
+
+		if !wt.IsMain {
+			wtCfg, cfgErr := config.Load(wt.Path)
+			if cfgErr != nil {
+				findings = append(findings, DoctorFinding{
+					Branch: wt.Branch,
+					Path:   wt.Path,
+					Kind:   "config-drift",
+					Detail: fmt.Sprintf("could not load .treepad.toml: %s", cfgErr),
+				})
+			} else if !reflect.DeepEqual(wtCfg, mainCfg) {
+				findings = append(findings, DoctorFinding{
+					Branch: wt.Branch,
+					Path:   wt.Path,
+					Kind:   "config-drift",
+					Detail: configDriftDetail(mainCfg, wtCfg),
+				})
+			}
+		}
+	}
+
+	if in.JSON {
+		return json.NewEncoder(s.out).Encode(findings)
+	}
+	s.writeDoctorTable(findings)
+
+	if in.Strict && len(findings) > 0 {
+		return fmt.Errorf("%d finding(s) reported", len(findings))
+	}
+	return nil
+}
+
+func (s *Service) writeDoctorTable(findings []DoctorFinding) {
+	if len(findings) == 0 {
+		_, _ = fmt.Fprintln(s.out, "no issues found")
+		return
+	}
+	w := tabwriter.NewWriter(s.out, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "KIND\tBRANCH\tDETAIL\tPATH")
+	for _, f := range findings {
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", f.Kind, f.Branch, f.Detail, collapsePath(f.Path))
+	}
+	_ = w.Flush()
+}
+
+func configDriftDetail(main, wt config.Config) string {
+	var sections []string
+	if !reflect.DeepEqual(main.Sync, wt.Sync) {
+		sections = append(sections, "sync")
+	}
+	if !reflect.DeepEqual(main.Artifact, wt.Artifact) {
+		sections = append(sections, "artifact")
+	}
+	if !reflect.DeepEqual(main.Open, wt.Open) {
+		sections = append(sections, "open")
+	}
+	return "differs in: " + strings.Join(sections, ", ")
+}

--- a/internal/treepad/service_doctor_test.go
+++ b/internal/treepad/service_doctor_test.go
@@ -52,12 +52,12 @@ func TestServiceDoctor(t *testing.T) {
 
 	t.Run("stale finding when last commit exceeds threshold", func(t *testing.T) {
 		runner := &seqRunner{responses: []runResponse{
-			{output: porcelain},              // git worktree list
-			{output: []byte("")},             // git branch --merged (nothing)
-			{output: recentCommitOutput("abc1234", "init")},  // log: main (recent)
-			{output: []byte("")},             // dirty: main (clean)
+			{output: porcelain},                                // git worktree list
+			{output: []byte("")},                               // git branch --merged (nothing)
+			{output: recentCommitOutput("abc1234", "init")},    // log: main (recent)
+			{output: []byte("")},                               // dirty: main (clean)
 			{output: staleCommitOutput("def5678", "old work")}, // log: feat (stale)
-			{output: []byte("")},             // dirty: feat (clean)
+			{output: []byte("")},                               // dirty: feat (clean)
 		}}
 		var buf strings.Builder
 		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
@@ -73,10 +73,6 @@ func TestServiceDoctor(t *testing.T) {
 		if !strings.Contains(out, "feat") {
 			t.Errorf("output missing 'feat' branch:\n%s", out)
 		}
-		if strings.Contains(out, "main") && strings.Contains(out, "stale") {
-			// main should not be flagged stale (recent commit)
-			// this is a loose check — just verify feat appears
-		}
 	})
 
 	t.Run("dirty-old finding supersedes stale when worktree is also dirty", func(t *testing.T) {
@@ -84,7 +80,7 @@ func TestServiceDoctor(t *testing.T) {
 			{output: porcelain},
 			{output: []byte("")},
 			{output: recentCommitOutput("abc1234", "init")},
-			{output: []byte("")},                                // dirty: main clean
+			{output: []byte("")},                               // dirty: main clean
 			{output: staleCommitOutput("def5678", "old work")}, // feat: stale
 			{output: []byte("M file.go\n")},                    // dirty: feat dirty
 		}}
@@ -109,10 +105,10 @@ func TestServiceDoctor(t *testing.T) {
 		runner := &seqRunner{responses: []runResponse{
 			{output: porcelain},
 			{output: []byte("feat\n")},                        // branch --merged: feat is merged
-			{output: recentCommitOutput("abc1234", "init")},  // log: main
-			{output: []byte("")},                             // dirty: main
+			{output: recentCommitOutput("abc1234", "init")},   // log: main
+			{output: []byte("")},                              // dirty: main
 			{output: recentCommitOutput("def5678", "feat x")}, // log: feat
-			{output: []byte("")},                             // dirty: feat
+			{output: []byte("")},                              // dirty: feat
 		}}
 		var buf strings.Builder
 		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
@@ -134,13 +130,13 @@ func TestServiceDoctor(t *testing.T) {
 		runner := &seqRunner{responses: []runResponse{
 			{output: porcelain},
 			{output: []byte("")},                              // branch --merged: none
-			{output: recentCommitOutput("abc1234", "init")},  // log: main
-			{output: []byte("")},                             // dirty: main
-			{err: errors.New("no upstream")},                 // rev-parse @{upstream}: main (none)
+			{output: recentCommitOutput("abc1234", "init")},   // log: main
+			{output: []byte("")},                              // dirty: main
+			{err: errors.New("no upstream")},                  // rev-parse @{upstream}: main (none)
 			{output: recentCommitOutput("def5678", "feat x")}, // log: feat
-			{output: []byte("")},                             // dirty: feat
-			{output: []byte("origin/feat\n")},                // rev-parse @{upstream}: feat has upstream
-			{output: []byte("")},                             // ls-remote: empty → branch gone
+			{output: []byte("")},                              // dirty: feat
+			{output: []byte("origin/feat\n")},                 // rev-parse @{upstream}: feat has upstream
+			{output: []byte("")},                              // ls-remote: empty → branch gone
 		}}
 		var buf strings.Builder
 		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
@@ -209,7 +205,7 @@ func TestServiceDoctor(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(featPath, ".treepad.toml"), []byte(toml), 0o644); err != nil {
 			t.Fatalf("setup: %v", err)
 		}
-		t.Cleanup(func() { os.Remove(filepath.Join(featPath, ".treepad.toml")) })
+		t.Cleanup(func() { _ = os.Remove(filepath.Join(featPath, ".treepad.toml")) })
 
 		runner := &seqRunner{responses: []runResponse{
 			{output: porcelain},

--- a/internal/treepad/service_doctor_test.go
+++ b/internal/treepad/service_doctor_test.go
@@ -1,0 +1,417 @@
+package treepad
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"treepad/internal/artifact"
+	internalsync "treepad/internal/sync"
+)
+
+// recentCommitOutput returns a git log line for a commit made 1 minute ago.
+func recentCommitOutput(sha, subject string) []byte {
+	t := time.Now().Add(-1 * time.Minute).Format(time.RFC3339)
+	return []byte(sha + "\x00" + subject + "\x00" + t + "\n")
+}
+
+// staleCommitOutput returns a git log line for a commit made 60 days ago.
+func staleCommitOutput(sha, subject string) []byte {
+	t := time.Now().Add(-60 * 24 * time.Hour).Format(time.RFC3339)
+	return []byte(sha + "\x00" + subject + "\x00" + t + "\n")
+}
+
+func TestServiceDoctor(t *testing.T) {
+	mainPath := t.TempDir()
+	if err := os.Mkdir(filepath.Join(mainPath, ".git"), 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	featPath := t.TempDir()
+	outputDir := t.TempDir()
+	porcelain := twoWorktreePorcelainWithMain(mainPath, featPath)
+
+	// offlineInput returns a DoctorInput with Offline=true so tests don't need
+	// to stub rev-parse / ls-remote calls unless specifically testing remote-gone.
+	offlineInput := func(extra ...func(*DoctorInput)) DoctorInput {
+		in := DoctorInput{
+			StaleDays: 30,
+			Base:      "main",
+			Offline:   true,
+			OutputDir: outputDir,
+		}
+		for _, f := range extra {
+			f(&in)
+		}
+		return in
+	}
+
+	t.Run("stale finding when last commit exceeds threshold", func(t *testing.T) {
+		runner := &seqRunner{responses: []runResponse{
+			{output: porcelain},              // git worktree list
+			{output: []byte("")},             // git branch --merged (nothing)
+			{output: recentCommitOutput("abc1234", "init")},  // log: main (recent)
+			{output: []byte("")},             // dirty: main (clean)
+			{output: staleCommitOutput("def5678", "old work")}, // log: feat (stale)
+			{output: []byte("")},             // dirty: feat (clean)
+		}}
+		var buf strings.Builder
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
+
+		err := svc.Doctor(context.Background(), offlineInput())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "stale") {
+			t.Errorf("output missing 'stale' finding:\n%s", out)
+		}
+		if !strings.Contains(out, "feat") {
+			t.Errorf("output missing 'feat' branch:\n%s", out)
+		}
+		if strings.Contains(out, "main") && strings.Contains(out, "stale") {
+			// main should not be flagged stale (recent commit)
+			// this is a loose check — just verify feat appears
+		}
+	})
+
+	t.Run("dirty-old finding supersedes stale when worktree is also dirty", func(t *testing.T) {
+		runner := &seqRunner{responses: []runResponse{
+			{output: porcelain},
+			{output: []byte("")},
+			{output: recentCommitOutput("abc1234", "init")},
+			{output: []byte("")},                                // dirty: main clean
+			{output: staleCommitOutput("def5678", "old work")}, // feat: stale
+			{output: []byte("M file.go\n")},                    // dirty: feat dirty
+		}}
+		var buf strings.Builder
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
+
+		err := svc.Doctor(context.Background(), offlineInput())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "dirty-old") {
+			t.Errorf("output missing 'dirty-old' finding:\n%s", out)
+		}
+		// stale should NOT appear separately when dirty-old is reported
+		if strings.Contains(out, "stale\t") {
+			t.Errorf("stale should not be reported alongside dirty-old:\n%s", out)
+		}
+	})
+
+	t.Run("merged-present finding when worktree branch is in merged set", func(t *testing.T) {
+		runner := &seqRunner{responses: []runResponse{
+			{output: porcelain},
+			{output: []byte("feat\n")},                        // branch --merged: feat is merged
+			{output: recentCommitOutput("abc1234", "init")},  // log: main
+			{output: []byte("")},                             // dirty: main
+			{output: recentCommitOutput("def5678", "feat x")}, // log: feat
+			{output: []byte("")},                             // dirty: feat
+		}}
+		var buf strings.Builder
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
+
+		err := svc.Doctor(context.Background(), offlineInput())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "merged-present") {
+			t.Errorf("output missing 'merged-present' finding:\n%s", out)
+		}
+		if !strings.Contains(out, "feat") {
+			t.Errorf("output missing 'feat' branch:\n%s", out)
+		}
+	})
+
+	t.Run("remote-gone finding when upstream configured but branch absent on remote", func(t *testing.T) {
+		runner := &seqRunner{responses: []runResponse{
+			{output: porcelain},
+			{output: []byte("")},                              // branch --merged: none
+			{output: recentCommitOutput("abc1234", "init")},  // log: main
+			{output: []byte("")},                             // dirty: main
+			{err: errors.New("no upstream")},                 // rev-parse @{upstream}: main (none)
+			{output: recentCommitOutput("def5678", "feat x")}, // log: feat
+			{output: []byte("")},                             // dirty: feat
+			{output: []byte("origin/feat\n")},                // rev-parse @{upstream}: feat has upstream
+			{output: []byte("")},                             // ls-remote: empty → branch gone
+		}}
+		var buf strings.Builder
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
+
+		in := DoctorInput{StaleDays: 30, Base: "main", Offline: false, OutputDir: outputDir}
+		err := svc.Doctor(context.Background(), in)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "remote-gone") {
+			t.Errorf("output missing 'remote-gone' finding:\n%s", out)
+		}
+	})
+
+	t.Run("offline flag skips remote-gone check", func(t *testing.T) {
+		runner := &seqRunner{responses: []runResponse{
+			{output: porcelain},
+			{output: []byte("")},
+			{output: recentCommitOutput("abc1234", "init")},
+			{output: []byte("")},
+			{output: recentCommitOutput("def5678", "feat x")},
+			{output: []byte("")},
+		}}
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
+
+		err := svc.Doctor(context.Background(), offlineInput())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// All 6 calls consumed; any 7th would trip seqRunner's out-of-bounds guard.
+		if runner.idx != 6 {
+			t.Errorf("runner called %d times, want 6 (rev-parse/ls-remote must be skipped)", runner.idx)
+		}
+	})
+
+	t.Run("artifact-missing finding when expected file is absent", func(t *testing.T) {
+		runner := &seqRunner{responses: []runResponse{
+			{output: porcelain},
+			{output: []byte("")},
+			{output: recentCommitOutput("abc1234", "init")},
+			{output: []byte("")},
+			{output: recentCommitOutput("def5678", "feat x")},
+			{output: []byte("")},
+		}}
+		// outputDir has no artifact files on disk → both worktrees flagged missing.
+		emptyOutputDir := t.TempDir()
+		var buf strings.Builder
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
+
+		err := svc.Doctor(context.Background(), offlineInput(func(in *DoctorInput) {
+			in.OutputDir = emptyOutputDir
+		}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "artifact-missing") {
+			t.Errorf("output missing 'artifact-missing' finding:\n%s", out)
+		}
+	})
+
+	t.Run("config-drift finding when worktree has different sync files", func(t *testing.T) {
+		// Write a .treepad.toml with different sync files to featPath.
+		toml := "[sync]\nfiles = [\"custom-file\"]\n"
+		if err := os.WriteFile(filepath.Join(featPath, ".treepad.toml"), []byte(toml), 0o644); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+		t.Cleanup(func() { os.Remove(filepath.Join(featPath, ".treepad.toml")) })
+
+		runner := &seqRunner{responses: []runResponse{
+			{output: porcelain},
+			{output: []byte("")},
+			{output: recentCommitOutput("abc1234", "init")},
+			{output: []byte("")},
+			{output: recentCommitOutput("def5678", "feat x")},
+			{output: []byte("")},
+		}}
+		var buf strings.Builder
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
+
+		err := svc.Doctor(context.Background(), offlineInput())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "config-drift") {
+			t.Errorf("output missing 'config-drift' finding:\n%s", out)
+		}
+		if !strings.Contains(out, "sync") {
+			t.Errorf("drift detail should mention 'sync':\n%s", out)
+		}
+	})
+
+	t.Run("no issues found message when everything is clean", func(t *testing.T) {
+		// Create artifact files so artifact-missing is not triggered.
+		artifactDir := t.TempDir()
+		repoSlug := strings.TrimSuffix(filepath.Base(mainPath), filepath.Ext(filepath.Base(mainPath)))
+		_ = os.WriteFile(filepath.Join(artifactDir, repoSlug+"-main.code-workspace"), []byte("{}"), 0o644)
+		_ = os.WriteFile(filepath.Join(artifactDir, repoSlug+"-feat.code-workspace"), []byte("{}"), 0o644)
+
+		runner := &seqRunner{responses: []runResponse{
+			{output: porcelain},
+			{output: []byte("")},
+			{output: recentCommitOutput("abc1234", "init")},
+			{output: []byte("")},
+			{output: recentCommitOutput("def5678", "feat x")},
+			{output: []byte("")},
+		}}
+		var buf strings.Builder
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
+
+		err := svc.Doctor(context.Background(), offlineInput(func(in *DoctorInput) {
+			in.OutputDir = artifactDir
+		}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(buf.String(), "no issues found") {
+			t.Errorf("expected 'no issues found'; got:\n%s", buf.String())
+		}
+	})
+
+	t.Run("json flag emits JSON array", func(t *testing.T) {
+		runner := &seqRunner{responses: []runResponse{
+			{output: porcelain},
+			{output: []byte("feat\n")}, // merged
+			{output: recentCommitOutput("abc1234", "init")},
+			{output: []byte("")},
+			{output: recentCommitOutput("def5678", "feat x")},
+			{output: []byte("")},
+		}}
+		var buf strings.Builder
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
+
+		err := svc.Doctor(context.Background(), offlineInput(func(in *DoctorInput) {
+			in.JSON = true
+		}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := buf.String()
+		if !strings.HasPrefix(out, "[") {
+			t.Errorf("expected JSON array, got: %s", out)
+		}
+		for _, want := range []string{`"kind"`, `"branch"`, "merged-present", "feat"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("JSON output missing %q:\n%s", want, out)
+			}
+		}
+	})
+
+	t.Run("strict returns error when findings exist", func(t *testing.T) {
+		runner := &seqRunner{responses: []runResponse{
+			{output: porcelain},
+			{output: []byte("feat\n")}, // merged → finding
+			{output: recentCommitOutput("abc1234", "init")},
+			{output: []byte("")},
+			{output: recentCommitOutput("def5678", "feat x")},
+			{output: []byte("")},
+		}}
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
+
+		err := svc.Doctor(context.Background(), offlineInput(func(in *DoctorInput) {
+			in.Strict = true
+		}))
+		if err == nil {
+			t.Fatal("expected error with --strict when findings exist, got nil")
+		}
+		if !strings.Contains(err.Error(), "finding") {
+			t.Errorf("error %q should mention findings", err)
+		}
+	})
+
+	t.Run("strict returns nil when no findings", func(t *testing.T) {
+		artifactDir := t.TempDir()
+		repoSlug := strings.TrimSuffix(filepath.Base(mainPath), filepath.Ext(filepath.Base(mainPath)))
+		_ = os.WriteFile(filepath.Join(artifactDir, repoSlug+"-main.code-workspace"), []byte("{}"), 0o644)
+		_ = os.WriteFile(filepath.Join(artifactDir, repoSlug+"-feat.code-workspace"), []byte("{}"), 0o644)
+
+		runner := &seqRunner{responses: []runResponse{
+			{output: porcelain},
+			{output: []byte("")},
+			{output: recentCommitOutput("abc1234", "init")},
+			{output: []byte("")},
+			{output: recentCommitOutput("def5678", "feat x")},
+			{output: []byte("")},
+		}}
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
+
+		err := svc.Doctor(context.Background(), offlineInput(func(in *DoctorInput) {
+			in.Strict = true
+			in.OutputDir = artifactDir
+		}))
+		if err != nil {
+			t.Fatalf("strict with no findings should return nil, got: %v", err)
+		}
+	})
+
+	t.Run("skips detached-head worktrees", func(t *testing.T) {
+		detachedPorcelain := []byte("worktree " + mainPath + "\nHEAD abc123\ndetached\n\n")
+		runner := &seqRunner{responses: []runResponse{
+			{output: detachedPorcelain},
+			{output: []byte("")}, // branch --merged
+			// no per-worktree calls because detached is skipped
+		}}
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
+
+		err := svc.Doctor(context.Background(), offlineInput())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if runner.idx != 2 {
+			t.Errorf("runner called %d times, want 2 (no per-wt calls for detached)", runner.idx)
+		}
+	})
+
+	errorTests := []struct {
+		name    string
+		runner  *seqRunner
+		wantErr string
+	}{
+		{
+			name: "git worktree list fails",
+			runner: &seqRunner{responses: []runResponse{
+				{err: errors.New("git not found")},
+			}},
+			wantErr: "git not found",
+		},
+		{
+			name: "git branch --merged fails",
+			runner: &seqRunner{responses: []runResponse{
+				{output: porcelain},
+				{err: errors.New("unknown revision")},
+			}},
+			wantErr: "unknown revision",
+		},
+		{
+			name: "last commit probe fails",
+			runner: &seqRunner{responses: []runResponse{
+				{output: porcelain},
+				{output: []byte("")},
+				{err: errors.New("git log failed")},
+			}},
+			wantErr: "git log failed",
+		},
+		{
+			name: "dirty probe fails",
+			runner: &seqRunner{responses: []runResponse{
+				{output: porcelain},
+				{output: []byte("")},
+				{output: recentCommitOutput("abc1234", "init")},
+				{err: errors.New("git status failed")},
+			}},
+			wantErr: "git status failed",
+		},
+	}
+	for _, tt := range errorTests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := NewService(tt.runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
+			err := svc.Doctor(context.Background(), offlineInput())
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("got error %v, want error containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// Ensure DoctorInput and DoctorFinding are usable in tests without importing
+// extra packages — smoke-test the types compile correctly.
+var _ = DoctorInput{}
+var _ = DoctorFinding{}
+var _ internalsync.Config
+var _ artifact.Spec

--- a/internal/worktree/remote.go
+++ b/internal/worktree/remote.go
@@ -1,0 +1,33 @@
+package worktree
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+)
+
+// RemoteBranchExists reports whether the branch at path has a configured
+// upstream tracking ref and whether that remote still has the branch.
+//
+// Returns (false, false, nil) when no upstream is configured — a local branch
+// that was never pushed is not a "remote-gone" finding.
+// Returns (false, true, nil) when an upstream is configured but the remote no
+// longer has the branch.
+func RemoteBranchExists(ctx context.Context, runner CommandRunner, path, branch string) (exists, hasUpstream bool, err error) {
+	out, err := runner.Run(ctx, "git", "-C", path, "rev-parse", "--abbrev-ref", "@{upstream}")
+	if err != nil {
+		return false, false, nil
+	}
+
+	remote := "origin"
+	if upstream := strings.TrimSpace(string(out)); strings.Contains(upstream, "/") {
+		remote = upstream[:strings.IndexByte(upstream, '/')]
+	}
+
+	lsOut, err := runner.Run(ctx, "git", "-C", path, "ls-remote", remote, "refs/heads/"+branch)
+	if err != nil {
+		return false, true, fmt.Errorf("git ls-remote: %w", err)
+	}
+	return len(bytes.TrimSpace(lsOut)) > 0, true, nil
+}

--- a/internal/worktree/remote_test.go
+++ b/internal/worktree/remote_test.go
@@ -9,21 +9,30 @@ import (
 
 func TestRemoteBranchExists(t *testing.T) {
 	tests := []struct {
-		name         string
-		responses    []struct{ output []byte; err error }
+		name      string
+		responses []struct {
+			output []byte
+			err    error
+		}
 		wantExists   bool
 		wantUpstream bool
 		wantErrStr   string
 	}{
 		{
-			name:         "no upstream configured",
-			responses:    []struct{ output []byte; err error }{{err: errors.New("fatal: no upstream configured")}},
+			name: "no upstream configured",
+			responses: []struct {
+				output []byte
+				err    error
+			}{{err: errors.New("fatal: no upstream configured")}},
 			wantExists:   false,
 			wantUpstream: false,
 		},
 		{
 			name: "branch exists on remote",
-			responses: []struct{ output []byte; err error }{
+			responses: []struct {
+				output []byte
+				err    error
+			}{
 				{output: []byte("origin/feat\n")},
 				{output: []byte("abc123\trefs/heads/feat\n")},
 			},
@@ -32,7 +41,10 @@ func TestRemoteBranchExists(t *testing.T) {
 		},
 		{
 			name: "branch gone from remote",
-			responses: []struct{ output []byte; err error }{
+			responses: []struct {
+				output []byte
+				err    error
+			}{
 				{output: []byte("origin/feat\n")},
 				{output: []byte("")},
 			},
@@ -41,7 +53,10 @@ func TestRemoteBranchExists(t *testing.T) {
 		},
 		{
 			name: "extracts remote name from upstream ref",
-			responses: []struct{ output []byte; err error }{
+			responses: []struct {
+				output []byte
+				err    error
+			}{
 				{output: []byte("upstream-remote/feat\n")},
 				{output: []byte("abc123\trefs/heads/feat\n")},
 			},
@@ -50,7 +65,10 @@ func TestRemoteBranchExists(t *testing.T) {
 		},
 		{
 			name: "ls-remote network failure",
-			responses: []struct{ output []byte; err error }{
+			responses: []struct {
+				output []byte
+				err    error
+			}{
 				{output: []byte("origin/feat\n")},
 				{err: errors.New("network unreachable")},
 			},

--- a/internal/worktree/remote_test.go
+++ b/internal/worktree/remote_test.go
@@ -1,0 +1,87 @@
+package worktree
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRemoteBranchExists(t *testing.T) {
+	tests := []struct {
+		name         string
+		responses    []struct{ output []byte; err error }
+		wantExists   bool
+		wantUpstream bool
+		wantErrStr   string
+	}{
+		{
+			name:         "no upstream configured",
+			responses:    []struct{ output []byte; err error }{{err: errors.New("fatal: no upstream configured")}},
+			wantExists:   false,
+			wantUpstream: false,
+		},
+		{
+			name: "branch exists on remote",
+			responses: []struct{ output []byte; err error }{
+				{output: []byte("origin/feat\n")},
+				{output: []byte("abc123\trefs/heads/feat\n")},
+			},
+			wantExists:   true,
+			wantUpstream: true,
+		},
+		{
+			name: "branch gone from remote",
+			responses: []struct{ output []byte; err error }{
+				{output: []byte("origin/feat\n")},
+				{output: []byte("")},
+			},
+			wantExists:   false,
+			wantUpstream: true,
+		},
+		{
+			name: "extracts remote name from upstream ref",
+			responses: []struct{ output []byte; err error }{
+				{output: []byte("upstream-remote/feat\n")},
+				{output: []byte("abc123\trefs/heads/feat\n")},
+			},
+			wantExists:   true,
+			wantUpstream: true,
+		},
+		{
+			name: "ls-remote network failure",
+			responses: []struct{ output []byte; err error }{
+				{output: []byte("origin/feat\n")},
+				{err: errors.New("network unreachable")},
+			},
+			wantExists:   false,
+			wantUpstream: true,
+			wantErrStr:   "git ls-remote",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &seqRunner{}
+			runner.responses = append(runner.responses, tt.responses...)
+
+			exists, hasUpstream, err := RemoteBranchExists(context.Background(), runner, "/repo", "feat")
+
+			if tt.wantErrStr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErrStr) {
+					t.Fatalf("got error %v, want error containing %q", err, tt.wantErrStr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if exists != tt.wantExists {
+				t.Errorf("exists = %v, want %v", exists, tt.wantExists)
+			}
+			if hasUpstream != tt.wantUpstream {
+				t.Errorf("hasUpstream = %v, want %v", hasUpstream, tt.wantUpstream)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `tp doctor` — a read-only cross-worktree health check that reports findings across all active worktrees
- Six check kinds: `stale`, `dirty-old`, `merged-present`, `remote-gone`, `artifact-missing`, `config-drift`
- Flags: `--stale-days` (default 30), `--base` (default main), `--offline` (skip network), `--strict` (non-zero exit on findings), `--json`
- New `worktree.RemoteBranchExists` helper; all other primitives reused from existing packages

## Test plan

- [ ] `go test ./...` passes (165 tests)
- [ ] `tp doctor --offline` lists merged-present worktrees in this repo
- [ ] `tp doctor --stale-days 0 --offline` flags all worktrees
- [ ] `tp doctor --offline --strict` exits non-zero when findings exist
- [ ] `tp doctor --offline --json` emits valid JSON array

🤖 Generated with [Claude Code](https://claude.com/claude-code)