### PR TITLE
feat: lifecycle hooks (pre/post_new, pre/post_remove, pre/post_sync)

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -10,6 +10,8 @@ tp workspace [options] [source-path]
 
 By default, uses the main worktree (the one with a `.git` directory) as the config source. Configs from `.vscode/`, `.claude/`, and `.env` files are copied to every other worktree. The artifact file generated is controlled by `.treepad.toml` and can be customized for any editor.
 
+**Hooks fired:** `pre_sync`/`post_sync` around each worktree's file sync. See [hooks.md](hooks.md).
+
 **Source resolution precedence:**
 1. Explicit `source-path` argument
 2. `--use-current` flag (current directory)
@@ -59,6 +61,8 @@ tp new [options] <branch>
 ```
 
 Creates a new worktree branched from a specified ref (default: `main`), syncs editor configs from the main worktree, and generates an artifact file as configured in `.treepad.toml`. By default, cd's into the new worktree directory when invoked via the shell wrapper (see [Shell integration](#shell-integration) below).
+
+**Hooks fired:** `pre_new` (before `git worktree add`), `pre_sync`/`post_sync` (around file sync), `post_new` (after artifact write). See [hooks.md](hooks.md).
 
 ### Flags
 
@@ -215,6 +219,8 @@ tp remove <branch>
 ```
 
 Removes the worktree for the specified branch, cleans up its associated artifact file (if any), and deletes the branch locally. Includes pre-flight safety guards to prevent accidental data loss.
+
+**Hooks fired:** `pre_remove` (before `git worktree remove`), `post_remove` (after `git branch -d`). See [hooks.md](hooks.md).
 
 ### Pre-flight guards
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,6 +66,27 @@ content = """{
 """
 ```
 
+### `[hooks]` section
+
+Shell commands to run at lifecycle points in `tp` operations. See [hooks.md](hooks.md) for the full reference.
+
+Each field is a list of shell command strings (Go `text/template` strings rendered before execution). An empty or absent list is a no-op.
+
+| Field | Type | Description |
+|---|---|---|
+| `pre_new` | string[] | Run before `git worktree add`; non-zero exit aborts the operation |
+| `post_new` | string[] | Run after artifact file is written; failure logs a warning |
+| `pre_remove` | string[] | Run before `git worktree remove`; non-zero exit aborts the operation |
+| `post_remove` | string[] | Run after `git branch -d`; failure logs a warning |
+| `pre_sync` | string[] | Run before each worktree's file sync; non-zero exit aborts that sync |
+| `post_sync` | string[] | Run after each worktree's file sync; failure logs a warning |
+
+```toml
+[hooks]
+post_new   = ["direnv allow {{.WorktreePath}}"]
+pre_remove = ["git -C {{.WorktreePath}} diff --exit-code HEAD"]
+```
+
 ### `[open]` section
 
 Command to run when `tp new --open` is used. Each element is a Go text/template string evaluated against the open context.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,133 @@
+# Hooks
+
+Hooks let you run shell commands at specific points in `tp`'s lifecycle — before or after creating worktrees, removing them, and syncing files. They are defined in `.treepad.toml` and run in the same shell environment as the `tp` process.
+
+## How hooks work
+
+- **Pre-hooks** (`pre_*`) run before the operation. If a pre-hook command exits non-zero, the operation is aborted and the error is returned to the caller.
+- **Post-hooks** (`post_*`) run after the operation completes. A failure is logged as a warning but never aborts the command.
+- Hooks run sequentially. If a command in a list fails, subsequent commands in that list are not run.
+- An empty or absent hook list is a no-op; there is no performance cost.
+
+## Events
+
+| Event | When it fires | Blocks on failure |
+|---|---|---|
+| `pre_new` | Before `git worktree add` | Yes |
+| `post_new` | After artifact file is written | No (warning logged) |
+| `pre_remove` | Before `git worktree remove` | Yes |
+| `post_remove` | After `git branch -d` | No (warning logged) |
+| `pre_sync` | Before each worktree's file sync | Yes |
+| `post_sync` | After each worktree's file sync | No (warning logged) |
+
+Sync events fire per-worktree. For `tp workspace` syncing three worktrees, `pre_sync`/`post_sync` fire three times.
+
+## Template variables
+
+Each hook command is a Go `text/template` string. The following variables are available:
+
+| Variable | Description |
+|---|---|
+| `{{.Branch}}` | Raw branch name (e.g. `feature/auth`) |
+| `{{.WorktreePath}}` | Absolute path of the worktree on disk |
+| `{{.Slug}}` | Repository slug (sanitized repo dir name, e.g. `myrepo`) |
+| `{{.HookType}}` | The event being fired (e.g. `post_new`) |
+| `{{.OutputDir}}` | Artifact output directory |
+
+Template rendering happens before the command is executed. A template error (e.g., referencing a non-existent field) is treated as a pre-hook failure.
+
+## Configuration
+
+Hooks are declared under `[hooks]` in `.treepad.toml`. Each field is a list of shell command strings, executed sequentially via `sh -c`.
+
+```toml
+[hooks]
+pre_new     = ["go mod download"]
+post_new    = [
+  "echo 'created {{.Branch}} at {{.WorktreePath}}' >> .treepad/activity.log",
+  "direnv allow {{.WorktreePath}}",
+]
+pre_remove  = ["git -C {{.WorktreePath}} diff --exit-code HEAD"]
+post_remove = []
+pre_sync    = []
+post_sync   = ["direnv allow {{.WorktreePath}}"]
+```
+
+Unset or empty lists are silently skipped. Unknown keys under `[hooks]` produce a parse error.
+
+> **Note:** Hooks are not supported on Windows in v1. `tp` returns an error if a hook is configured and executed on `GOOS=windows`.
+
+## Execution model
+
+- Each list entry is rendered as a Go template, then passed to `sh -c <rendered>`.
+- Commands run with the working directory inherited from the `tp` process (usually the directory you invoked `tp` from).
+- Environment variables are inherited from the `tp` process.
+- Standard output and error from hook commands are not currently captured or displayed; post-hook failures appear as `warning: post hook <event> failed: <error>` in `tp` output.
+
+## Example use cases
+
+### Bootstrap a new agent worktree
+
+Run dependency install and generate a seed task file when a new worktree is created. The agent opens to a ready environment.
+
+```toml
+[hooks]
+post_new = [
+  "cd {{.WorktreePath}} && go mod download",
+  "cp .env.example {{.WorktreePath}}/.env",
+  "echo '# Task: {{.Branch}}\n\nSee CLAUDE.md for context.' > {{.WorktreePath}}/TASK.md",
+]
+```
+
+### Refuse removal of dirty worktrees
+
+Block `tp remove` if the worktree has uncommitted changes, preventing accidental data loss.
+
+```toml
+[hooks]
+pre_remove = [
+  "git -C {{.WorktreePath}} diff --exit-code HEAD",
+]
+```
+
+If the diff exits non-zero (dirty), `tp remove` aborts with a hook error before touching anything.
+
+### Auto-approve direnv per worktree
+
+Allow the new worktree's `.envrc` after sync so environment variables are live before the agent opens.
+
+```toml
+[hooks]
+post_sync = ["direnv allow {{.WorktreePath}}"]
+```
+
+Because `post_sync` fires per-worktree, every synced directory gets approved.
+
+### Log agent activity to a shared file
+
+Append to a repo-level activity log on every worktree creation. Foreshadows the shared-state work (`.treepad/state.toml`) without coupling to it.
+
+```toml
+[hooks]
+post_new    = ["echo \"$(date -u +%FT%TZ) created {{.Branch}}\" >> .treepad/activity.log"]
+post_remove = ["echo \"$(date -u +%FT%TZ) removed {{.Branch}}\" >> .treepad/activity.log"]
+```
+
+### Run linters before sync overwrites
+
+Guard against syncing a broken config into all worktrees.
+
+```toml
+[hooks]
+pre_sync = ["./scripts/validate-vscode-settings.sh"]
+```
+
+## Limitations and roadmap
+
+| Limitation | Notes |
+|---|---|
+| Repo-level only | Global `~/.config/treepad/config.toml` hooks are not merged in v1 |
+| No approval flow | All configured hooks execute unconditionally (no first-run approval gate) |
+| No concurrent hooks | Commands within a list run sequentially; parallel execution is not supported |
+| Windows not supported | `sh -c` execution path; `cmd /C` fallback is deferred |
+| No per-branch `vars` | Branch-specific variable scratchpad is part of the shared-state feature (`.treepad/state.toml`), not hooks |

--- a/internal/commands/cd.go
+++ b/internal/commands/cd.go
@@ -8,6 +8,7 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"treepad/internal/artifact"
+	"treepad/internal/hook"
 	internalsync "treepad/internal/sync"
 	"treepad/internal/treepad"
 	"treepad/internal/worktree"
@@ -33,6 +34,7 @@ func runCD(ctx context.Context, cmd *cli.Command) error {
 		runner,
 		internalsync.FileSyncer{},
 		artifact.ExecOpener{Runner: runner},
+		hook.ExecRunner{Runner: runner},
 		os.Stdout,
 		os.Stdin,
 	)

--- a/internal/commands/doctor.go
+++ b/internal/commands/doctor.go
@@ -7,6 +7,7 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"treepad/internal/artifact"
+	"treepad/internal/hook"
 	internalsync "treepad/internal/sync"
 	"treepad/internal/treepad"
 	"treepad/internal/worktree"
@@ -33,6 +34,7 @@ func runDoctor(ctx context.Context, cmd *cli.Command) error {
 		runner,
 		internalsync.FileSyncer{},
 		artifact.ExecOpener{Runner: runner},
+		hook.ExecRunner{Runner: runner},
 		os.Stdout,
 		os.Stdin,
 	)

--- a/internal/commands/new.go
+++ b/internal/commands/new.go
@@ -8,6 +8,7 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"treepad/internal/artifact"
+	"treepad/internal/hook"
 	internalsync "treepad/internal/sync"
 	"treepad/internal/treepad"
 	"treepad/internal/worktree"
@@ -50,6 +51,7 @@ func runNew(ctx context.Context, cmd *cli.Command) error {
 		runner,
 		internalsync.FileSyncer{},
 		artifact.ExecOpener{Runner: runner},
+		hook.ExecRunner{Runner: runner},
 		os.Stdout,
 		os.Stdin,
 	)

--- a/internal/commands/prune.go
+++ b/internal/commands/prune.go
@@ -7,6 +7,7 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"treepad/internal/artifact"
+	"treepad/internal/hook"
 	internalsync "treepad/internal/sync"
 	"treepad/internal/treepad"
 	"treepad/internal/worktree"
@@ -31,6 +32,7 @@ func runPrune(ctx context.Context, cmd *cli.Command) error {
 		runner,
 		internalsync.FileSyncer{},
 		artifact.ExecOpener{Runner: runner},
+		hook.ExecRunner{Runner: runner},
 		os.Stdout,
 		os.Stdin,
 	)

--- a/internal/commands/remove.go
+++ b/internal/commands/remove.go
@@ -8,6 +8,7 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"treepad/internal/artifact"
+	"treepad/internal/hook"
 	internalsync "treepad/internal/sync"
 	"treepad/internal/treepad"
 	"treepad/internal/worktree"
@@ -33,6 +34,7 @@ func runRemove(ctx context.Context, cmd *cli.Command) error {
 		runner,
 		internalsync.FileSyncer{},
 		artifact.ExecOpener{Runner: runner},
+		hook.ExecRunner{Runner: runner},
 		os.Stdout,
 		os.Stdin,
 	)

--- a/internal/commands/status.go
+++ b/internal/commands/status.go
@@ -7,6 +7,7 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"treepad/internal/artifact"
+	"treepad/internal/hook"
 	internalsync "treepad/internal/sync"
 	"treepad/internal/treepad"
 	"treepad/internal/worktree"
@@ -29,6 +30,7 @@ func runStatus(ctx context.Context, cmd *cli.Command) error {
 		runner,
 		internalsync.FileSyncer{},
 		artifact.ExecOpener{Runner: runner},
+		hook.ExecRunner{Runner: runner},
 		os.Stdout,
 		os.Stdin,
 	)

--- a/internal/commands/workspace.go
+++ b/internal/commands/workspace.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/urfave/cli/v3"
 
+	"treepad/internal/hook"
 	internalsync "treepad/internal/sync"
 	"treepad/internal/treepad"
 	"treepad/internal/worktree"
@@ -49,7 +50,8 @@ func runWorkspace(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("--use-current and a source path argument are mutually exclusive")
 	}
 
-	svc := treepad.NewService(worktree.ExecRunner{}, internalsync.FileSyncer{}, nil, os.Stdout, os.Stdin)
+	runner := worktree.ExecRunner{}
+	svc := treepad.NewService(runner, internalsync.FileSyncer{}, nil, hook.ExecRunner{Runner: runner}, os.Stdout, os.Stdin)
 	return svc.Generate(ctx, treepad.GenerateInput{
 		UseCurrentDir: useCurrentFlag,
 		SourcePath:    sourcePath,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 
 	"github.com/BurntSushi/toml"
+
+	"treepad/internal/hook"
 )
 
 const configFileName = ".treepad.toml"
@@ -80,6 +82,7 @@ type Config struct {
 	Sync     SyncConfig     `toml:"sync"`
 	Artifact ArtifactConfig `toml:"artifact"`
 	Open     OpenConfig     `toml:"open"`
+	Hooks    hook.Config    `toml:"hooks"`
 }
 
 // GlobalConfigPath returns the path to the global config file.
@@ -134,6 +137,9 @@ func Load(repoRoot string) (Config, error) {
 	}
 	if !fileCfg.Open.IsZero() {
 		cfg.Open = fileCfg.Open
+	}
+	if !fileCfg.Hooks.IsZero() {
+		cfg.Hooks = fileCfg.Hooks
 	}
 
 	slog.Debug("loaded .treepad.toml", "dir", repoRoot, "syncFiles", cfg.Sync.Files)

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -1,0 +1,67 @@
+// Package hook runs lifecycle hooks defined in .treepad.toml.
+package hook
+
+import "context"
+
+// Event identifies a lifecycle point in a treepad operation.
+type Event string
+
+const (
+	PreNew     Event = "pre_new"
+	PostNew    Event = "post_new"
+	PreRemove  Event = "pre_remove"
+	PostRemove Event = "post_remove"
+	PreSync    Event = "pre_sync"
+	PostSync   Event = "post_sync"
+)
+
+// Data is the context available when rendering hook command templates.
+type Data struct {
+	Branch       string // raw branch name
+	WorktreePath string // absolute path of the worktree on disk
+	Slug         string // repo slug
+	HookType     string // event being fired, e.g. "post_new"
+	OutputDir    string // artifact output directory
+}
+
+// Runner executes a list of hook commands with the provided data.
+type Runner interface {
+	Run(ctx context.Context, hooks []string, data Data) error
+}
+
+// Config holds the hook command lists for each event.
+type Config struct {
+	PreNew     []string `toml:"pre_new"`
+	PostNew    []string `toml:"post_new"`
+	PreRemove  []string `toml:"pre_remove"`
+	PostRemove []string `toml:"post_remove"`
+	PreSync    []string `toml:"pre_sync"`
+	PostSync   []string `toml:"post_sync"`
+}
+
+// IsZero reports whether no hooks are configured.
+func (c Config) IsZero() bool {
+	return len(c.PreNew) == 0 && len(c.PostNew) == 0 &&
+		len(c.PreRemove) == 0 && len(c.PostRemove) == 0 &&
+		len(c.PreSync) == 0 && len(c.PostSync) == 0
+}
+
+// For returns the hook commands for the given event.
+func (c Config) For(e Event) []string {
+	switch e {
+	case PreNew:
+		return c.PreNew
+	case PostNew:
+		return c.PostNew
+	case PreRemove:
+		return c.PreRemove
+	case PostRemove:
+		return c.PostRemove
+	case PreSync:
+		return c.PreSync
+	case PostSync:
+		return c.PostSync
+	default:
+		return nil
+	}
+}

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -1,0 +1,147 @@
+package hook_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"treepad/internal/hook"
+)
+
+type fakeRunner struct {
+	calls [][]string
+	err   error
+}
+
+func (f *fakeRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	entry := append([]string{name}, args...)
+	f.calls = append(f.calls, entry)
+	return nil, f.err
+}
+
+var testData = hook.Data{
+	Branch:       "feat/foo",
+	WorktreePath: "/repo/feat-foo",
+	Slug:         "myrepo",
+	HookType:     "post_new",
+	OutputDir:    "/tmp/workspaces",
+}
+
+func TestExecRunnerRun(t *testing.T) {
+	t.Run("renders template and runs via sh -c", func(t *testing.T) {
+		r := &fakeRunner{}
+		runner := hook.ExecRunner{Runner: r}
+
+		if err := runner.Run(context.Background(), []string{"echo {{.Branch}}"}, testData); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(r.calls) != 1 {
+			t.Fatalf("got %d calls, want 1", len(r.calls))
+		}
+		got := r.calls[0]
+		if got[0] != "sh" || got[1] != "-c" || got[2] != "echo feat/foo" {
+			t.Errorf("unexpected call args: %v", got)
+		}
+	})
+
+	t.Run("empty list is no-op", func(t *testing.T) {
+		r := &fakeRunner{}
+		runner := hook.ExecRunner{Runner: r}
+
+		if err := runner.Run(context.Background(), nil, testData); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(r.calls) != 0 {
+			t.Errorf("got %d calls, want 0", len(r.calls))
+		}
+	})
+
+	t.Run("stops on first error", func(t *testing.T) {
+		r := &fakeRunner{err: errors.New("exit status 1")}
+		runner := hook.ExecRunner{Runner: r}
+
+		if err := runner.Run(context.Background(), []string{"cmd1", "cmd2"}, testData); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if len(r.calls) != 1 {
+			t.Errorf("got %d calls, want 1 (should stop after first failure)", len(r.calls))
+		}
+	})
+
+	t.Run("runs multiple hooks sequentially", func(t *testing.T) {
+		r := &fakeRunner{}
+		runner := hook.ExecRunner{Runner: r}
+
+		if err := runner.Run(context.Background(), []string{"cmd1", "cmd2"}, testData); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(r.calls) != 2 {
+			t.Errorf("got %d calls, want 2", len(r.calls))
+		}
+	})
+
+	t.Run("invalid template returns error before exec", func(t *testing.T) {
+		r := &fakeRunner{}
+		runner := hook.ExecRunner{Runner: r}
+
+		if err := runner.Run(context.Background(), []string{"echo {{.Invalid"}, testData); err == nil {
+			t.Fatal("expected error for bad template, got nil")
+		}
+		if len(r.calls) != 0 {
+			t.Errorf("got %d runner calls, want 0 (should fail before exec)", len(r.calls))
+		}
+	})
+
+	t.Run("all template fields available", func(t *testing.T) {
+		r := &fakeRunner{}
+		runner := hook.ExecRunner{Runner: r}
+
+		cmd := "{{.Branch}} {{.WorktreePath}} {{.Slug}} {{.HookType}} {{.OutputDir}}"
+		if err := runner.Run(context.Background(), []string{cmd}, testData); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := "feat/foo /repo/feat-foo myrepo post_new /tmp/workspaces"
+		if got := r.calls[0][2]; got != want {
+			t.Errorf("rendered = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestConfigFor(t *testing.T) {
+	cfg := hook.Config{
+		PreNew:     []string{"a"},
+		PostNew:    []string{"b", "c"},
+		PreRemove:  []string{"d"},
+		PostRemove: []string{"e"},
+		PreSync:    []string{"f"},
+		PostSync:   []string{"g"},
+	}
+
+	tests := []struct {
+		event hook.Event
+		want  []string
+	}{
+		{hook.PreNew, []string{"a"}},
+		{hook.PostNew, []string{"b", "c"}},
+		{hook.PreRemove, []string{"d"}},
+		{hook.PostRemove, []string{"e"}},
+		{hook.PreSync, []string{"f"}},
+		{hook.PostSync, []string{"g"}},
+		{"unknown", nil},
+	}
+	for _, tt := range tests {
+		got := cfg.For(tt.event)
+		if len(got) != len(tt.want) {
+			t.Errorf("For(%q): got %v, want %v", tt.event, got, tt.want)
+		}
+	}
+}
+
+func TestConfigIsZero(t *testing.T) {
+	if !(hook.Config{}).IsZero() {
+		t.Error("empty Config.IsZero() = false, want true")
+	}
+	if (hook.Config{PreNew: []string{"x"}}).IsZero() {
+		t.Error("non-empty Config.IsZero() = true, want false")
+	}
+}

--- a/internal/hook/runner.go
+++ b/internal/hook/runner.go
@@ -1,0 +1,48 @@
+package hook
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"runtime"
+	"text/template"
+)
+
+// CommandRunner executes a system command.
+type CommandRunner interface {
+	Run(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+// ExecRunner renders each hook command as a text/template and executes it via sh -c.
+type ExecRunner struct {
+	Runner CommandRunner
+}
+
+// Run executes each hook sequentially, stopping on the first error.
+func (e ExecRunner) Run(ctx context.Context, hooks []string, data Data) error {
+	if runtime.GOOS == "windows" {
+		return fmt.Errorf("hooks are not supported on Windows")
+	}
+	for _, tmpl := range hooks {
+		rendered, err := renderCommand(tmpl, data)
+		if err != nil {
+			return fmt.Errorf("render hook %q: %w", tmpl, err)
+		}
+		if _, err := e.Runner.Run(ctx, "sh", "-c", rendered); err != nil {
+			return fmt.Errorf("hook %q: %w", rendered, err)
+		}
+	}
+	return nil
+}
+
+func renderCommand(tmpl string, data Data) (string, error) {
+	t, err := template.New("hook").Parse(tmpl)
+	if err != nil {
+		return "", fmt.Errorf("parse: %w", err)
+	}
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("execute: %w", err)
+	}
+	return buf.String(), nil
+}

--- a/internal/treepad/service.go
+++ b/internal/treepad/service.go
@@ -13,21 +13,23 @@ import (
 
 	"treepad/internal/artifact"
 	"treepad/internal/config"
+	"treepad/internal/hook"
 	"treepad/internal/slug"
 	internalsync "treepad/internal/sync"
 	"treepad/internal/worktree"
 )
 
 type Service struct {
-	runner worktree.CommandRunner
-	syncer internalsync.Syncer
-	opener artifact.Opener
-	out    io.Writer
-	in     io.Reader
+	runner     worktree.CommandRunner
+	syncer     internalsync.Syncer
+	opener     artifact.Opener
+	hookRunner hook.Runner
+	out        io.Writer
+	in         io.Reader
 }
 
-func NewService(runner worktree.CommandRunner, syncer internalsync.Syncer, opener artifact.Opener, out io.Writer, in io.Reader) *Service {
-	return &Service{runner: runner, syncer: syncer, opener: opener, out: out, in: in}
+func NewService(runner worktree.CommandRunner, syncer internalsync.Syncer, opener artifact.Opener, hookRunner hook.Runner, out io.Writer, in io.Reader) *Service {
+	return &Service{runner: runner, syncer: syncer, opener: opener, hookRunner: hookRunner, out: out, in: in}
 }
 
 type GenerateInput struct {
@@ -95,7 +97,7 @@ func (s *Service) Generate(ctx context.Context, in GenerateInput) error {
 		}
 		targets = append(targets, syncTarget{path: wt.Path, branch: wt.Branch})
 	}
-	cfg, err := s.loadAndSync(sourceDir, in.ExtraPatterns, targets)
+	cfg, err := s.loadAndSync(ctx, sourceDir, in.ExtraPatterns, targets, repoSlug, outputDir)
 	if err != nil {
 		return err
 	}
@@ -137,18 +139,27 @@ func (s *Service) New(ctx context.Context, in NewInput) error {
 	worktreePath := filepath.Join(filepath.Dir(mainWT.Path), repoSlug+"-"+slug.Slug(in.Branch))
 	slog.Debug("derived worktree path", "path", worktreePath)
 
+	outputDir, err := s.resolveOutputDir(in.OutputDir, repoSlug)
+	if err != nil {
+		return err
+	}
+
+	cfg, err := config.Load(mainWT.Path)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	hData := s.hookData(repoSlug, in.Branch, worktreePath, outputDir)
+	if err := s.runPreHook(ctx, hook.PreNew, cfg.Hooks.For(hook.PreNew), hData); err != nil {
+		return fmt.Errorf("pre_new hook: %w", err)
+	}
+
 	if _, err := s.runner.Run(ctx, "git", "worktree", "add", "-b", in.Branch, worktreePath, in.Base); err != nil {
 		return fmt.Errorf("git worktree add: %w", err)
 	}
 	_, _ = fmt.Fprintf(s.out, "created worktree at %s\n", worktreePath)
 
-	cfg, err := s.loadAndSync(mainWT.Path, nil, []syncTarget{{path: worktreePath, branch: in.Branch}})
-	if err != nil {
-		return err
-	}
-
-	outputDir, err := s.resolveOutputDir(in.OutputDir, repoSlug)
-	if err != nil {
+	if err := s.syncTargets(ctx, cfg, mainWT.Path, nil, []syncTarget{{path: worktreePath, branch: in.Branch}}, repoSlug, outputDir); err != nil {
 		return err
 	}
 
@@ -158,6 +169,8 @@ func (s *Service) New(ctx context.Context, in NewInput) error {
 		return fmt.Errorf("write artifact: %w", err)
 	}
 	slog.Debug("wrote artifact", "outputDir", outputDir, "branch", in.Branch)
+
+	s.runPostHook(ctx, hook.PostNew, cfg.Hooks.For(hook.PostNew), hData)
 
 	if in.Open {
 		openPath := worktreePath
@@ -359,17 +372,22 @@ func (s *Service) pruneAll(ctx context.Context, worktrees []worktree.Worktree, m
 }
 
 func (s *Service) removeWorktree(ctx context.Context, target worktree.Worktree, mainWT worktree.Worktree, outputDir string) error {
-	if _, err := s.runner.Run(ctx, "git", "worktree", "remove", target.Path); err != nil {
-		return fmt.Errorf("git worktree remove: %w", err)
-	}
-	_, _ = fmt.Fprintf(s.out, "removed worktree: %s\n", target.Path)
-
 	cfg, err := config.Load(mainWT.Path)
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
 
 	repoSlug := slug.Slug(filepath.Base(mainWT.Path))
+	hData := s.hookData(repoSlug, target.Branch, target.Path, outputDir)
+	if err := s.runPreHook(ctx, hook.PreRemove, cfg.Hooks.For(hook.PreRemove), hData); err != nil {
+		return fmt.Errorf("pre_remove hook: %w", err)
+	}
+
+	if _, err := s.runner.Run(ctx, "git", "worktree", "remove", target.Path); err != nil {
+		return fmt.Errorf("git worktree remove: %w", err)
+	}
+	_, _ = fmt.Fprintf(s.out, "removed worktree: %s\n", target.Path)
+
 	data := s.templateData(repoSlug, target.Branch, target.Path, outputDir)
 	artifactPath, ok, err := artifact.Path(artifactSpec(cfg.Artifact), outputDir, data)
 	if err != nil {
@@ -387,21 +405,28 @@ func (s *Service) removeWorktree(ctx context.Context, target worktree.Worktree, 
 	}
 	_, _ = fmt.Fprintf(s.out, "deleted branch: %s\n", target.Branch)
 
+	s.runPostHook(ctx, hook.PostRemove, cfg.Hooks.For(hook.PostRemove), hData)
+
 	return nil
 }
 
 func (s *Service) forceRemoveWorktree(ctx context.Context, target worktree.Worktree, mainWT worktree.Worktree, outputDir string) error {
-	if _, err := s.runner.Run(ctx, "git", "worktree", "remove", "--force", target.Path); err != nil {
-		return fmt.Errorf("git worktree remove --force: %w", err)
-	}
-	_, _ = fmt.Fprintf(s.out, "removed worktree: %s\n", target.Path)
-
 	cfg, err := config.Load(mainWT.Path)
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
 
 	repoSlug := slug.Slug(filepath.Base(mainWT.Path))
+	hData := s.hookData(repoSlug, target.Branch, target.Path, outputDir)
+	if err := s.runPreHook(ctx, hook.PreRemove, cfg.Hooks.For(hook.PreRemove), hData); err != nil {
+		return fmt.Errorf("pre_remove hook: %w", err)
+	}
+
+	if _, err := s.runner.Run(ctx, "git", "worktree", "remove", "--force", target.Path); err != nil {
+		return fmt.Errorf("git worktree remove --force: %w", err)
+	}
+	_, _ = fmt.Fprintf(s.out, "removed worktree: %s\n", target.Path)
+
 	data := s.templateData(repoSlug, target.Branch, target.Path, outputDir)
 	artifactPath, ok, err := artifact.Path(artifactSpec(cfg.Artifact), outputDir, data)
 	if err != nil {
@@ -418,6 +443,8 @@ func (s *Service) forceRemoveWorktree(ctx context.Context, target worktree.Workt
 		return fmt.Errorf("git branch -D: %w", err)
 	}
 	_, _ = fmt.Fprintf(s.out, "deleted branch: %s\n", target.Branch)
+
+	s.runPostHook(ctx, hook.PostRemove, cfg.Hooks.For(hook.PostRemove), hData)
 
 	return nil
 }
@@ -450,16 +477,22 @@ func (s *Service) resolveOutputDir(explicit string, repoSlug string) (string, er
 	return filepath.Join(home, repoSlug+"-workspaces"), nil
 }
 
-// loadAndSync loads config from sourceDir, syncs it to targets, and returns the config.
-// Pass a nil targets slice to skip syncing and only load the config.
-func (s *Service) loadAndSync(sourceDir string, extraPatterns []string, targets []syncTarget) (config.Config, error) {
+// loadAndSync loads config from sourceDir, syncs to targets with pre/post_sync hooks, and returns the config.
+func (s *Service) loadAndSync(ctx context.Context, sourceDir string, extraPatterns []string, targets []syncTarget, repoSlug, outputDir string) (config.Config, error) {
 	cfg, err := config.Load(sourceDir)
 	if err != nil {
 		return config.Config{}, fmt.Errorf("load config: %w", err)
 	}
+	if err := s.syncTargets(ctx, cfg, sourceDir, extraPatterns, targets, repoSlug, outputDir); err != nil {
+		return config.Config{}, err
+	}
+	return cfg, nil
+}
 
+// syncTargets syncs files from sourceDir to each target, firing pre_sync/post_sync hooks around each.
+func (s *Service) syncTargets(ctx context.Context, cfg config.Config, sourceDir string, extraPatterns []string, targets []syncTarget, repoSlug, outputDir string) error {
 	if len(targets) == 0 {
-		return cfg, nil
+		return nil
 	}
 
 	patterns := slices.Concat(cfg.Sync.Files, extraPatterns)
@@ -468,15 +501,20 @@ func (s *Service) loadAndSync(sourceDir string, extraPatterns []string, targets 
 	_, _ = fmt.Fprintln(s.out, "\nsyncing configs to worktrees...")
 	for _, t := range targets {
 		_, _ = fmt.Fprintf(s.out, "  → %s (%s)\n", t.branch, t.path)
+		hData := s.hookData(repoSlug, t.branch, t.path, outputDir)
+		if err := s.runPreHook(ctx, hook.PreSync, cfg.Hooks.For(hook.PreSync), hData); err != nil {
+			return fmt.Errorf("pre_sync hook for %s: %w", t.branch, err)
+		}
 		if err := s.syncer.Sync(patterns, internalsync.Config{
 			SourceDir: sourceDir,
 			TargetDir: t.path,
 		}); err != nil {
-			return config.Config{}, fmt.Errorf("sync configs to %s: %w", t.branch, err)
+			return fmt.Errorf("sync configs to %s: %w", t.branch, err)
 		}
+		s.runPostHook(ctx, hook.PostSync, cfg.Hooks.For(hook.PostSync), hData)
 		slog.Debug("synced worktree", "branch", t.branch, "target", t.path)
 	}
-	return cfg, nil
+	return nil
 }
 
 func artifactSpec(c config.ArtifactConfig) artifact.Spec {
@@ -493,5 +531,34 @@ func (s *Service) templateData(repoSlug, branch, worktreePath, outputDir string)
 		Branch:    wt.Name,
 		Worktrees: []artifact.Worktree{wt},
 		OutputDir: outputDir,
+	}
+}
+
+func (s *Service) hookData(repoSlug, branch, worktreePath, outputDir string) hook.Data {
+	return hook.Data{
+		Branch:       branch,
+		WorktreePath: worktreePath,
+		Slug:         repoSlug,
+		OutputDir:    outputDir,
+	}
+}
+
+// runPreHook runs blocking pre-event hooks. A non-zero exit aborts the operation.
+func (s *Service) runPreHook(ctx context.Context, event hook.Event, hooks []string, data hook.Data) error {
+	if len(hooks) == 0 {
+		return nil
+	}
+	data.HookType = string(event)
+	return s.hookRunner.Run(ctx, hooks, data)
+}
+
+// runPostHook runs post-event hooks. Failures are logged but never abort the operation.
+func (s *Service) runPostHook(ctx context.Context, event hook.Event, hooks []string, data hook.Data) {
+	if len(hooks) == 0 {
+		return
+	}
+	data.HookType = string(event)
+	if err := s.hookRunner.Run(ctx, hooks, data); err != nil {
+		_, _ = fmt.Fprintf(s.out, "warning: post hook %s failed: %v\n", event, err)
 	}
 }

--- a/internal/treepad/service_cd_test.go
+++ b/internal/treepad/service_cd_test.go
@@ -31,7 +31,7 @@ func TestServiceCD(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var out bytes.Buffer
-			svc := NewService(fakeRunner{output: twoWorktreePorcelain}, &fakeSyncer{}, nil, &out, strings.NewReader(""))
+			svc := NewService(fakeRunner{output: twoWorktreePorcelain}, &fakeSyncer{}, nil, &fakeHookRunner{}, &out, strings.NewReader(""))
 
 			err := svc.CD(context.Background(), CDInput{Branch: tt.branch})
 

--- a/internal/treepad/service_doctor_test.go
+++ b/internal/treepad/service_doctor_test.go
@@ -60,7 +60,7 @@ func TestServiceDoctor(t *testing.T) {
 			{output: []byte("")},                               // dirty: feat (clean)
 		}}
 		var buf strings.Builder
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, &buf, strings.NewReader(""))
 
 		err := svc.Doctor(context.Background(), offlineInput())
 		if err != nil {
@@ -85,7 +85,7 @@ func TestServiceDoctor(t *testing.T) {
 			{output: []byte("M file.go\n")},                    // dirty: feat dirty
 		}}
 		var buf strings.Builder
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, &buf, strings.NewReader(""))
 
 		err := svc.Doctor(context.Background(), offlineInput())
 		if err != nil {
@@ -111,7 +111,7 @@ func TestServiceDoctor(t *testing.T) {
 			{output: []byte("")},                              // dirty: feat
 		}}
 		var buf strings.Builder
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, &buf, strings.NewReader(""))
 
 		err := svc.Doctor(context.Background(), offlineInput())
 		if err != nil {
@@ -139,7 +139,7 @@ func TestServiceDoctor(t *testing.T) {
 			{output: []byte("")},                              // ls-remote: empty → branch gone
 		}}
 		var buf strings.Builder
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, &buf, strings.NewReader(""))
 
 		in := DoctorInput{StaleDays: 30, Base: "main", Offline: false, OutputDir: outputDir}
 		err := svc.Doctor(context.Background(), in)
@@ -161,7 +161,7 @@ func TestServiceDoctor(t *testing.T) {
 			{output: recentCommitOutput("def5678", "feat x")},
 			{output: []byte("")},
 		}}
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, io.Discard, strings.NewReader(""))
 
 		err := svc.Doctor(context.Background(), offlineInput())
 		if err != nil {
@@ -185,7 +185,7 @@ func TestServiceDoctor(t *testing.T) {
 		// outputDir has no artifact files on disk → both worktrees flagged missing.
 		emptyOutputDir := t.TempDir()
 		var buf strings.Builder
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, &buf, strings.NewReader(""))
 
 		err := svc.Doctor(context.Background(), offlineInput(func(in *DoctorInput) {
 			in.OutputDir = emptyOutputDir
@@ -216,7 +216,7 @@ func TestServiceDoctor(t *testing.T) {
 			{output: []byte("")},
 		}}
 		var buf strings.Builder
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, &buf, strings.NewReader(""))
 
 		err := svc.Doctor(context.Background(), offlineInput())
 		if err != nil {
@@ -247,7 +247,7 @@ func TestServiceDoctor(t *testing.T) {
 			{output: []byte("")},
 		}}
 		var buf strings.Builder
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, &buf, strings.NewReader(""))
 
 		err := svc.Doctor(context.Background(), offlineInput(func(in *DoctorInput) {
 			in.OutputDir = artifactDir
@@ -270,7 +270,7 @@ func TestServiceDoctor(t *testing.T) {
 			{output: []byte("")},
 		}}
 		var buf strings.Builder
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, &buf, strings.NewReader(""))
 
 		err := svc.Doctor(context.Background(), offlineInput(func(in *DoctorInput) {
 			in.JSON = true
@@ -298,7 +298,7 @@ func TestServiceDoctor(t *testing.T) {
 			{output: recentCommitOutput("def5678", "feat x")},
 			{output: []byte("")},
 		}}
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, io.Discard, strings.NewReader(""))
 
 		err := svc.Doctor(context.Background(), offlineInput(func(in *DoctorInput) {
 			in.Strict = true
@@ -325,7 +325,7 @@ func TestServiceDoctor(t *testing.T) {
 			{output: recentCommitOutput("def5678", "feat x")},
 			{output: []byte("")},
 		}}
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, io.Discard, strings.NewReader(""))
 
 		err := svc.Doctor(context.Background(), offlineInput(func(in *DoctorInput) {
 			in.Strict = true
@@ -343,7 +343,7 @@ func TestServiceDoctor(t *testing.T) {
 			{output: []byte("")}, // branch --merged
 			// no per-worktree calls because detached is skipped
 		}}
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, io.Discard, strings.NewReader(""))
 
 		err := svc.Doctor(context.Background(), offlineInput())
 		if err != nil {
@@ -396,7 +396,7 @@ func TestServiceDoctor(t *testing.T) {
 	}
 	for _, tt := range errorTests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := NewService(tt.runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
+			svc := NewService(tt.runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, io.Discard, strings.NewReader(""))
 			err := svc.Doctor(context.Background(), offlineInput())
 			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 				t.Errorf("got error %v, want error containing %q", err, tt.wantErr)

--- a/internal/treepad/service_test.go
+++ b/internal/treepad/service_test.go
@@ -311,7 +311,7 @@ func TestServiceNew(t *testing.T) {
 		if err := os.WriteFile(tomlPath, []byte("[hooks]\npre_new = [\"check\"]\n"), 0o644); err != nil {
 			t.Fatalf("setup: %v", err)
 		}
-		defer os.Remove(tomlPath)
+		defer func() { _ = os.Remove(tomlPath) }()
 
 		svc := NewService(rec, &fakeSyncer{}, &fakeOpener{}, hr, io.Discard, strings.NewReader(""))
 		err := svc.New(context.Background(), NewInput{Branch: "feature/auth", Base: "main", OutputDir: outputDir})
@@ -335,7 +335,7 @@ func TestServiceNew(t *testing.T) {
 		if err := os.WriteFile(tomlPath, []byte("[hooks]\npost_new = [\"notify\"]\n"), 0o644); err != nil {
 			t.Fatalf("setup: %v", err)
 		}
-		defer os.Remove(tomlPath)
+		defer func() { _ = os.Remove(tomlPath) }()
 
 		var buf strings.Builder
 		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, hr, &buf, strings.NewReader(""))
@@ -464,7 +464,7 @@ func TestServiceRemove(t *testing.T) {
 		if err := os.WriteFile(tomlPath, []byte("[hooks]\npre_remove = [\"check-clean\"]\n"), 0o644); err != nil {
 			t.Fatalf("setup: %v", err)
 		}
-		defer os.Remove(tomlPath)
+		defer func() { _ = os.Remove(tomlPath) }()
 
 		svc := NewService(rec, &fakeSyncer{}, &fakeOpener{}, hr, io.Discard, strings.NewReader(""))
 		err := svc.Remove(context.Background(), RemoveInput{Branch: "feat", OutputDir: outputDir})
@@ -491,7 +491,7 @@ func TestServiceRemove(t *testing.T) {
 		if err := os.WriteFile(tomlPath, []byte("[hooks]\npost_remove = [\"notify\"]\n"), 0o644); err != nil {
 			t.Fatalf("setup: %v", err)
 		}
-		defer os.Remove(tomlPath)
+		defer func() { _ = os.Remove(tomlPath) }()
 
 		var buf strings.Builder
 		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, hr, &buf, strings.NewReader(""))

--- a/internal/treepad/service_test.go
+++ b/internal/treepad/service_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"treepad/internal/artifact"
+	"treepad/internal/hook"
 	"treepad/internal/slug"
 	internalsync "treepad/internal/sync"
 	"treepad/internal/worktree"
@@ -65,6 +66,21 @@ func (f *fakeOpener) Open(_ context.Context, _ artifact.OpenSpec, data artifact.
 	return f.err
 }
 
+type hookCall struct {
+	hooks []string
+	data  hook.Data
+}
+
+type fakeHookRunner struct {
+	calls []hookCall
+	err   error
+}
+
+func (f *fakeHookRunner) Run(_ context.Context, hooks []string, data hook.Data) error {
+	f.calls = append(f.calls, hookCall{hooks: hooks, data: data})
+	return f.err
+}
+
 // twoWorktreePorcelain produces two worktrees; IsMain will be false for both
 // in tests since the paths don't exist on disk. Tests use SourcePath to
 // bypass the main-worktree lookup.
@@ -85,7 +101,7 @@ func mainWorktreePorcelain(mainPath string) []byte {
 
 func newTestService(t *testing.T, runner worktree.CommandRunner, syncer internalsync.Syncer, opener artifact.Opener) *Service {
 	t.Helper()
-	return NewService(runner, syncer, opener, io.Discard, strings.NewReader(""))
+	return NewService(runner, syncer, opener, &fakeHookRunner{}, io.Discard, strings.NewReader(""))
 }
 
 // recordingRunner records every Run call and delegates to an inner seqRunner.
@@ -155,6 +171,28 @@ func TestServiceGenerate(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("pre_sync failure aborts sync", func(t *testing.T) {
+		// Use a real sourceDir so config.Load finds the .treepad.toml with pre_sync configured.
+		sourceDir := t.TempDir()
+		tomlPath := filepath.Join(sourceDir, ".treepad.toml")
+		if err := os.WriteFile(tomlPath, []byte("[hooks]\npre_sync = [\"check\"]\n"), 0o644); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+
+		syn := &fakeSyncer{}
+		hr := &fakeHookRunner{err: errors.New("pre_sync blocked")}
+		// fakeRunner returns twoWorktreePorcelain for git worktree list.
+		svc := NewService(fakeRunner{output: twoWorktreePorcelain}, syn, nil, hr, io.Discard, strings.NewReader(""))
+
+		err := svc.Generate(context.Background(), GenerateInput{SourcePath: sourceDir, SyncOnly: true})
+		if err == nil || !strings.Contains(err.Error(), "pre_sync blocked") {
+			t.Errorf("expected pre_sync error, got: %v", err)
+		}
+		if len(syn.calls) != 0 {
+			t.Errorf("syncer should not have been called when pre_sync hook fails")
+		}
+	})
 }
 
 func TestServiceNew(t *testing.T) {
@@ -172,7 +210,7 @@ func TestServiceNew(t *testing.T) {
 		}}
 		syn := &fakeSyncer{}
 		opener := &fakeOpener{}
-		svc := NewService(runner, syn, opener, io.Discard, strings.NewReader(""))
+		svc := NewService(runner, syn, opener, &fakeHookRunner{}, io.Discard, strings.NewReader(""))
 
 		err := svc.New(context.Background(), NewInput{
 			Branch:    "feature/auth",
@@ -199,7 +237,7 @@ func TestServiceNew(t *testing.T) {
 			{output: nil},
 		}}
 		opener := &fakeOpener{}
-		svc := NewService(runner, &fakeSyncer{}, opener, io.Discard, strings.NewReader(""))
+		svc := NewService(runner, &fakeSyncer{}, opener, &fakeHookRunner{}, io.Discard, strings.NewReader(""))
 
 		err := svc.New(context.Background(), NewInput{
 			Branch:    "feature/auth",
@@ -225,7 +263,7 @@ func TestServiceNew(t *testing.T) {
 			{output: nil},
 		}}
 		var buf strings.Builder
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, &buf, strings.NewReader(""))
 
 		err := svc.New(context.Background(), NewInput{
 			Branch:    "feature/auth",
@@ -246,7 +284,7 @@ func TestServiceNew(t *testing.T) {
 			{output: nil},
 		}}
 		var buf strings.Builder
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, &buf, strings.NewReader(""))
 
 		err := svc.New(context.Background(), NewInput{
 			Branch:    "feature/auth",
@@ -259,6 +297,54 @@ func TestServiceNew(t *testing.T) {
 		}
 		if strings.Contains(buf.String(), "__TREEPAD_CD__") {
 			t.Errorf("cd directive should be absent when Current=true; got:\n%s", buf.String())
+		}
+	})
+
+	t.Run("pre_new failure aborts before git worktree add", func(t *testing.T) {
+		rec := &recordingRunner{inner: &seqRunner{responses: []runResponse{
+			{output: porcelain},
+		}}}
+		hr := &fakeHookRunner{err: errors.New("pre_new blocked")}
+
+		// Write a .treepad.toml with a pre_new hook so cfg.Hooks.For(PreNew) is non-empty.
+		tomlPath := filepath.Join(mainPath, ".treepad.toml")
+		if err := os.WriteFile(tomlPath, []byte("[hooks]\npre_new = [\"check\"]\n"), 0o644); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+		defer os.Remove(tomlPath)
+
+		svc := NewService(rec, &fakeSyncer{}, &fakeOpener{}, hr, io.Discard, strings.NewReader(""))
+		err := svc.New(context.Background(), NewInput{Branch: "feature/auth", Base: "main", OutputDir: outputDir})
+		if err == nil || !strings.Contains(err.Error(), "pre_new blocked") {
+			t.Errorf("expected pre_new error, got: %v", err)
+		}
+		// Only git worktree list should have been called; git worktree add must not have run.
+		if len(rec.calls) != 1 {
+			t.Errorf("runner called %d times, want 1 (list only); calls: %v", len(rec.calls), rec.calls)
+		}
+	})
+
+	t.Run("post_new failure is logged but New succeeds", func(t *testing.T) {
+		runner := &seqRunner{responses: []runResponse{
+			{output: porcelain},
+			{output: nil}, // git worktree add
+		}}
+		hr := &fakeHookRunner{err: errors.New("post_new problem")}
+
+		tomlPath := filepath.Join(mainPath, ".treepad.toml")
+		if err := os.WriteFile(tomlPath, []byte("[hooks]\npost_new = [\"notify\"]\n"), 0o644); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+		defer os.Remove(tomlPath)
+
+		var buf strings.Builder
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, hr, &buf, strings.NewReader(""))
+		err := svc.New(context.Background(), NewInput{Branch: "feature/auth", Base: "main", OutputDir: outputDir})
+		if err != nil {
+			t.Errorf("post_new failure should not abort New, got: %v", err)
+		}
+		if !strings.Contains(buf.String(), "warning: post hook post_new failed") {
+			t.Errorf("expected warning in output; got:\n%s", buf.String())
 		}
 	})
 
@@ -297,7 +383,7 @@ func TestServiceNew(t *testing.T) {
 	}
 	for _, tt := range errorTests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := NewService(tt.runner, tt.syncer, &fakeOpener{}, io.Discard, strings.NewReader(""))
+			svc := NewService(tt.runner, tt.syncer, &fakeOpener{}, &fakeHookRunner{}, io.Discard, strings.NewReader(""))
 			err := svc.New(context.Background(), NewInput{
 				Branch:    "feature/auth",
 				Base:      "main",
@@ -339,7 +425,7 @@ func TestServiceRemove(t *testing.T) {
 			{},                  // git worktree remove
 			{},                  // git branch -d
 		}}
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, io.Discard, strings.NewReader(""))
 
 		err := svc.Remove(context.Background(), RemoveInput{Branch: "feat", OutputDir: outputDir})
 		if err != nil {
@@ -360,11 +446,61 @@ func TestServiceRemove(t *testing.T) {
 			{},
 			{},
 		}}
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, io.Discard, strings.NewReader(""))
 
 		err := svc.Remove(context.Background(), RemoveInput{Branch: "feat", OutputDir: outputDir})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("pre_remove failure aborts before git worktree remove", func(t *testing.T) {
+		rec := &recordingRunner{inner: &seqRunner{responses: []runResponse{
+			{output: porcelain},
+		}}}
+		hr := &fakeHookRunner{err: errors.New("dirty worktree")}
+
+		tomlPath := filepath.Join(mainPath, ".treepad.toml")
+		if err := os.WriteFile(tomlPath, []byte("[hooks]\npre_remove = [\"check-clean\"]\n"), 0o644); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+		defer os.Remove(tomlPath)
+
+		svc := NewService(rec, &fakeSyncer{}, &fakeOpener{}, hr, io.Discard, strings.NewReader(""))
+		err := svc.Remove(context.Background(), RemoveInput{Branch: "feat", OutputDir: outputDir})
+		if err == nil || !strings.Contains(err.Error(), "dirty worktree") {
+			t.Errorf("expected pre_remove error, got: %v", err)
+		}
+		// Only git worktree list should have been called.
+		for _, call := range rec.calls {
+			if len(call) >= 3 && call[2] == "remove" {
+				t.Errorf("git worktree remove should not have been called; calls: %v", rec.calls)
+			}
+		}
+	})
+
+	t.Run("post_remove failure is logged but Remove succeeds", func(t *testing.T) {
+		runner := &seqRunner{responses: []runResponse{
+			{output: porcelain},
+			{}, // git worktree remove
+			{}, // git branch -d
+		}}
+		hr := &fakeHookRunner{err: errors.New("post_remove problem")}
+
+		tomlPath := filepath.Join(mainPath, ".treepad.toml")
+		if err := os.WriteFile(tomlPath, []byte("[hooks]\npost_remove = [\"notify\"]\n"), 0o644); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+		defer os.Remove(tomlPath)
+
+		var buf strings.Builder
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, hr, &buf, strings.NewReader(""))
+		err := svc.Remove(context.Background(), RemoveInput{Branch: "feat", OutputDir: outputDir})
+		if err != nil {
+			t.Errorf("post_remove failure should not abort Remove, got: %v", err)
+		}
+		if !strings.Contains(buf.String(), "warning: post hook post_remove failed") {
+			t.Errorf("expected warning in output; got:\n%s", buf.String())
 		}
 	})
 
@@ -420,7 +556,7 @@ func TestServiceRemove(t *testing.T) {
 	}
 	for _, tt := range errorTests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := NewService(tt.runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
+			svc := NewService(tt.runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, io.Discard, strings.NewReader(""))
 			err := svc.Remove(context.Background(), RemoveInput{Branch: tt.branch, OutputDir: outputDir})
 			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 				t.Errorf("got error %v, want error containing %q", err, tt.wantErr)
@@ -432,7 +568,7 @@ func TestServiceRemove(t *testing.T) {
 		runner := &seqRunner{responses: []runResponse{
 			{output: porcelain},
 		}}
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, io.Discard, strings.NewReader(""))
 
 		err := svc.Remove(context.Background(), RemoveInput{
 			Branch:    "feat",
@@ -472,7 +608,7 @@ func TestServicePrune(t *testing.T) {
 			{output: twoPorcelain},     // git worktree list
 			{output: []byte("feat\n")}, // git branch --merged
 		}}
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, io.Discard, strings.NewReader(""))
 
 		err := svc.Prune(context.Background(), PruneInput{Base: "main", OutputDir: outputDir, DryRun: true})
 		if err != nil {
@@ -495,7 +631,7 @@ func TestServicePrune(t *testing.T) {
 			{},                         // git worktree remove
 			{},                         // git branch -d
 		}}
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, io.Discard, strings.NewReader(""))
 
 		err := svc.Prune(context.Background(), PruneInput{Base: "main", OutputDir: outputDir})
 		if err != nil {
@@ -514,7 +650,7 @@ func TestServicePrune(t *testing.T) {
 			{output: twoPorcelain},
 			{output: []byte("")}, // nothing merged
 		}}
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, io.Discard, strings.NewReader(""))
 
 		err := svc.Prune(context.Background(), PruneInput{Base: "main", OutputDir: outputDir})
 		if err != nil {
@@ -532,7 +668,7 @@ func TestServicePrune(t *testing.T) {
 			{},                                // git worktree remove (other)
 			{},                                // git branch -d (other)
 		}}
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, io.Discard, strings.NewReader(""))
 
 		// cwd is inside featPath — feat should be skipped, other should be removed
 		err := svc.Prune(context.Background(), PruneInput{
@@ -556,7 +692,7 @@ func TestServicePrune(t *testing.T) {
 			{},                                   // git worktree remove other
 			{},                                   // git branch -d other
 		}}
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, io.Discard, strings.NewReader(""))
 
 		err := svc.Prune(context.Background(), PruneInput{Base: "main", OutputDir: outputDir})
 		if err == nil {
@@ -593,7 +729,7 @@ func TestServicePrune(t *testing.T) {
 	}
 	for _, tt := range errorTests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := NewService(tt.runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
+			svc := NewService(tt.runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, io.Discard, strings.NewReader(""))
 			err := svc.Prune(context.Background(), PruneInput{Base: "main", OutputDir: outputDir})
 			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 				t.Errorf("got error %v, want error containing %q", err, tt.wantErr)
@@ -605,7 +741,7 @@ func TestServicePrune(t *testing.T) {
 		runner := &seqRunner{responses: []runResponse{
 			{output: twoPorcelain}, // git worktree list
 		}}
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, io.Discard, strings.NewReader(""))
 
 		err := svc.Prune(context.Background(), PruneInput{
 			All:       true,
@@ -628,7 +764,7 @@ func TestServicePrune(t *testing.T) {
 			{output: threePorcelain}, // git worktree list
 		}}
 		var buf strings.Builder
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, &buf, strings.NewReader(""))
 
 		err := svc.Prune(context.Background(), PruneInput{
 			All:       true,
@@ -656,7 +792,7 @@ func TestServicePrune(t *testing.T) {
 			{output: twoPorcelain}, // git worktree list
 		}}
 		var buf strings.Builder
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader("n\n"))
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, &buf, strings.NewReader("n\n"))
 
 		err := svc.Prune(context.Background(), PruneInput{
 			All:       true,
@@ -685,7 +821,7 @@ func TestServicePrune(t *testing.T) {
 			{},                     // git worktree remove --force
 			{},                     // git branch -D
 		}}}
-		svc := NewService(rec, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader("y\n"))
+		svc := NewService(rec, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, io.Discard, strings.NewReader("y\n"))
 
 		err := svc.Prune(context.Background(), PruneInput{
 			All:       true,
@@ -749,7 +885,7 @@ func TestServiceStatus(t *testing.T) {
 		}}
 
 		var buf strings.Builder
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, &buf, strings.NewReader(""))
 		err := svc.Status(context.Background(), StatusInput{OutputDir: outputDir})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -776,7 +912,7 @@ func TestServiceStatus(t *testing.T) {
 			{output: commitOutput("def5678", "add x")},
 		}}
 		var buf strings.Builder
-		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &buf, strings.NewReader(""))
+		svc := NewService(runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, &buf, strings.NewReader(""))
 		err := svc.Status(context.Background(), StatusInput{JSON: true, OutputDir: outputDir})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -825,7 +961,7 @@ func TestServiceStatus(t *testing.T) {
 	}
 	for _, tt := range errorTests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := NewService(tt.runner, &fakeSyncer{}, &fakeOpener{}, io.Discard, strings.NewReader(""))
+			svc := NewService(tt.runner, &fakeSyncer{}, &fakeOpener{}, &fakeHookRunner{}, io.Discard, strings.NewReader(""))
 			err := svc.Status(context.Background(), StatusInput{OutputDir: outputDir})
 			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 				t.Errorf("got error %v, want error containing %q", err, tt.wantErr)


### PR DESCRIPTION
## Summary

- Adds a `[hooks]` section to `.treepad.toml` with six events: `pre_new`, `post_new`, `pre_remove`, `post_remove`, `pre_sync`, `post_sync`
- Pre-hooks block the operation on non-zero exit; post-hooks log a warning and continue
- Each hook is a list of Go `text/template` shell commands executed sequentially via `sh -c`
- New `internal/hook/` package — `Event`, `Data`, `Runner` interface, `Config`, `ExecRunner`
- Adds `docs/hooks.md` with full reference, template variable table, and five use-case examples (agent bootstrap, dirty-worktree guard, direnv, activity log, pre-sync lint)

## Test plan

- [ ] `go test ./...` passes (156 tests)
- [ ] `pre_new` hook failure aborts before `git worktree add` (verified in `TestServiceNew/pre_new_failure_aborts_before_git_worktree_add`)
- [ ] `post_new` failure logs warning but `tp new` returns nil (verified in `TestServiceNew/post_new_failure_is_logged_but_New_succeeds`)
- [ ] `pre_remove` failure aborts before `git worktree remove` (verified in `TestServiceRemove/pre_remove_failure_aborts_before_git_worktree_remove`)
- [ ] `post_remove` failure logs warning but `tp remove` returns nil (verified)
- [ ] `pre_sync` failure with real `.treepad.toml` aborts sync and does not call syncer (verified in `TestServiceGenerate/pre_sync_failure_aborts_sync`)
- [ ] Template rendering, stop-on-error, empty-list no-op covered in `internal/hook/hook_test.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)