### PR TITLE
feat: add tp exec command for running commands in any worktree

### DIFF
--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -80,18 +80,30 @@ Central location for all CLI command definitions. Separates CLI wiring from busi
   - Calls `Status()`
   - Creates instances of `worktree.ExecRunner`, `sync.FileSyncer`, `artifact.ExecOpener`
 
+### `exec.go`
+
+- `execCommand()` — top-level exec command definition
+  - Usage: `tp exec <branch> [command] [args...]`
+  - Parses branch argument (required), optional command, and variadic args
+- `runExec(ctx, cmd)` — action handler for executing commands in worktrees
+  - Instantiates `treepad.Service` with `os.Stdout` and `os.Stdin`
+  - Calls `Exec()` with branch, command, and args
+  - Returns exit code from child process via `cli.Exit("")
+
 ## Config Package (`internal/config/`)
 
 Handles TOML configuration file loading, initialization, and display.
 
 ### `config.go`
 
-- `Config` struct — root config object with `Sync`, `Artifact`, `Open` fields
+- `Config` struct — root config object with `Sync`, `Artifact`, `Open`, `Exec` fields
 - `SyncConfig` struct — contains `Files` (string array)
 - `ArtifactConfig` struct — contains `FilenameTemplate` and `ContentTemplate` (text/template strings)
   - `IsZero()` — reports whether artifact is configured
 - `OpenConfig` struct — contains `Command` (string slice of template strings)
   - `IsZero()` — reports whether open command is configured
+- `ExecConfig` struct — contains `Runner` (string; valid values: just, npm, pnpm, yarn, bun, make, pip, poetry, uv)
+  - `IsZero()` — reports whether exec runner is explicitly configured
 - `GlobalConfigPath()` — resolves global config path
   - Resolution order: `$TREEPAD_CONFIG` → `$XDG_CONFIG_HOME/treepad/config.toml` → `~/.config/treepad/config.toml`
 - `Load(repoRoot)` — loads `.treepad.toml` from repo, falls back to defaults
@@ -115,6 +127,28 @@ Handles TOML configuration file loading, initialization, and display.
 - `loadFile(path)` — reads and parses a single `.treepad.toml` file
   - Returns triple: (Config, found bool, error)
   - Handles missing files and parse errors
+
+## Exec Package (`internal/exec/`)
+
+Task runner detection and script enumeration for the `tp exec` command.
+
+### `runner.go`
+
+- `Runner` struct — describes a detected task runner
+  - Fields: `Name` (e.g. "just", "pnpm"), `ScriptCmd` (prefix before script name, e.g. ["pnpm", "run"]), `Scripts` (enumerated script names, sorted)
+- `Detect(worktreePath, override)` — identifies task runner in worktree
+  - Checks for marker files in order: justfile, package.json, Makefile, pyproject.toml
+  - Returns error if multiple runners detected and no override specified
+  - Uses override if provided (from `[exec] runner` in `.treepad.toml`)
+  - Enumerates available scripts via `ListScripts()`
+- `ListScripts(worktreePath, runnerName)` — enumerates scripts for a given runner
+  - Supports: just, npm, pnpm, yarn, bun, poetry, uv, make, pip
+  - Returns nil for runners without script enumeration (make, pip)
+- `detectJSManager(dir)` — selects npm/pnpm/yarn/bun based on lockfile presence and package.json `packageManager` field
+- `detectPythonRunner(dir)` — selects poetry or uv based on pyproject.toml contents
+- `listJustRecipes(dir)` — parses justfile and extracts recipe names (excludes private recipes starting with `_`)
+- `listPackageJSONScripts(dir)` — parses package.json and extracts script names
+- `listPyprojectScripts(dir)` — parses pyproject.toml and extracts script names (checks `[project]` scripts first, then `[tool.poetry]`)
 
 ## Treepad Package (`internal/treepad/`)
 
@@ -145,6 +179,12 @@ Pure business logic for worktree syncing and artifact file generation. Formerly 
     - Input: `JSON` (emit JSON instead of table), `OutputDir` (for artifact path resolution)
     - Output: builds `[]StatusRow` with branch, dirty state, ahead/behind count, last commit info, artifact mtime
     - Renders as aligned table via `text/tabwriter` by default, or JSON array with `--json` flag
+  - `Exec(ctx, ExecInput)` — runs a command in a named worktree with full stdio passthrough
+    - Input: `Branch`, `Command`, `Args`, `Cwd` (for testing), `Runner` (PassthroughRunner override)
+    - Detects task runner via `internal/exec.Detect()` using config override if available
+    - If `Command` is empty: lists detected runner and available scripts, returns
+    - Otherwise: builds command via `buildCommand()` (routes through runner if command matches enumerated script)
+    - Executes via PassthroughRunner and returns child process exit code (non-zero does not produce an error)
 - Private helpers:
   - `removeWorktree(ctx, target, mainWT, outputDir)` — removes a single worktree (merge-safe removal), deletes artifact, deletes branch
   - `forceRemoveWorktree(ctx, target, mainWT, outputDir)` — force-removes a worktree via `git worktree remove --force`, deletes artifact, force-deletes branch via `git branch -D`
@@ -152,6 +192,8 @@ Pure business logic for worktree syncing and artifact file generation. Formerly 
   - `listWorktrees(ctx)` — lists all worktrees in repo
   - `resolveOutputDir(explicit, repoSlug)` — resolves artifact output directory
   - `loadAndSync(sourceDir, extraPatterns, targets)` — loads config and syncs to targets; returns `config.Config` so artifact config is available
+  - `printScripts(runner)` — prints runner name and enumerated scripts to output
+  - `buildCommand(runner, command, extraArgs)` — returns executable name and arguments, routing through runner if command matches a known script (adds `--` for npm with extra args)
 
 ### `source.go`
 
@@ -247,6 +289,10 @@ tp [--verbose] <command>
 │   └── --all (force-remove all non-main, must be from main)
 ├── status [options]
 │   └── --json
+├── exec <branch> [command] [args...]
+│   └── Auto-detects task runner (just, npm, pnpm, yarn, bun, make, poetry, uv)
+│       Routes through runner if command matches enumerated script
+│       Override with [exec] runner in .treepad.toml
 └── config
     ├── init [--global]
     └── show
@@ -351,6 +397,22 @@ tp [--verbose] <command>
    - If `--json` flag set, encodes as JSON array; otherwise renders via `text/tabwriter` table
    - Writes to `s.out` and returns
 
+## Data Flow Example: `tp exec <branch> [command] [args...]`
+
+1. `cmd/tp/main.go` parses flags and calls `commands.Router()`
+2. `commands.execCommand()` defines CLI interface
+3. `runExec()` parses branch, optional command, and variadic args; instantiates `treepad.Service`, calls `Exec()`
+4. `Service.Exec()` executes:
+   - Lists all worktrees via `worktree.List()` and finds target by branch
+   - Checks if already in target worktree (emits warning if so)
+   - Loads config and detects task runner via `exec.Detect()` (uses override if configured)
+   - If command is empty: prints runner name and available scripts via `printScripts()`
+   - Otherwise: builds command via `buildCommand()`:
+     - If command matches enumerated script: routes through runner (e.g. "build" → ["pnpm", "run", "build"])
+     - Otherwise: executes raw command in worktree root
+   - Executes via PassthroughRunner with full stdio passthrough (inherits stdin/stdout/stderr from tp process)
+   - Returns exit code from child process (non-zero exit does not produce an error; launch failures do)
+
 ---
 
-**Last Updated:** April 15, 2026 (added `--all` flag to `prune` command for force-removing all non-main worktrees with confirmation prompt; added `io.Reader` to `Service` for stdin access)
+**Last Updated:** April 15, 2026 (added `tp exec` command with task runner detection, script enumeration, and full stdio passthrough; added `internal/exec` package and `service_exec.go`; added `ExecConfig` to config package)

--- a/README.md
+++ b/README.md
@@ -145,6 +145,21 @@ tp status
 tp status --json
 ```
 
+**`exec`** — Run a command in a specific worktree with full stdio passthrough:
+
+```bash
+# Run a script (detected task runner handles it automatically)
+tp exec feature-x build
+
+# Run a raw command in the worktree root
+tp exec feature-x cargo test
+
+# List available scripts and detected runner for a worktree
+tp exec feature-x
+```
+
+The `exec` command auto-detects the project task runner (just, npm/pnpm/yarn/bun, make, poetry/uv) by checking for marker files. If the command matches an enumerated script, it routes through the runner (e.g. `just build`, `pnpm run build`). Otherwise, it executes the command directly in the worktree root. Override auto-detection via `[exec] runner = "just"` in `.treepad.toml`.
+
 **`config`** — Manage tp configuration:
 
 ```bash

--- a/internal/commands/exec.go
+++ b/internal/commands/exec.go
@@ -1,0 +1,61 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/urfave/cli/v3"
+
+	"treepad/internal/artifact"
+	"treepad/internal/hook"
+	internalsync "treepad/internal/sync"
+	"treepad/internal/treepad"
+	"treepad/internal/worktree"
+)
+
+func execCommand() *cli.Command {
+	return &cli.Command{
+		Name:      "exec",
+		Usage:     "run a command in a specific worktree",
+		ArgsUsage: "<branch> [command] [args...]",
+		Action:    runExec,
+	}
+}
+
+func runExec(ctx context.Context, cmd *cli.Command) error {
+	args := cmd.Args().Slice()
+	if len(args) == 0 {
+		return fmt.Errorf("branch name is required")
+	}
+
+	branch := args[0]
+	var command string
+	var cmdArgs []string
+	if len(args) > 1 {
+		command = args[1]
+		cmdArgs = args[2:]
+	}
+
+	runner := worktree.ExecRunner{}
+	svc := treepad.NewService(
+		runner,
+		internalsync.FileSyncer{},
+		artifact.ExecOpener{Runner: runner},
+		hook.ExecRunner{Runner: runner},
+		os.Stdout,
+		os.Stdin,
+	)
+	result, err := svc.Exec(ctx, treepad.ExecInput{
+		Branch:  branch,
+		Command: command,
+		Args:    cmdArgs,
+	})
+	if err != nil {
+		return err
+	}
+	if result.ExitCode != 0 {
+		return cli.Exit("", result.ExitCode)
+	}
+	return nil
+}

--- a/internal/commands/exec.go
+++ b/internal/commands/exec.go
@@ -11,6 +11,7 @@ import (
 	"treepad/internal/hook"
 	internalsync "treepad/internal/sync"
 	"treepad/internal/treepad"
+	"treepad/internal/ui"
 	"treepad/internal/worktree"
 )
 
@@ -43,8 +44,9 @@ func runExec(ctx context.Context, cmd *cli.Command) error {
 		internalsync.FileSyncer{},
 		artifact.ExecOpener{Runner: runner},
 		hook.ExecRunner{Runner: runner},
-		os.Stdout,
+		cmd.Root().Writer,
 		os.Stdin,
+		ui.New(cmd.Root().ErrWriter),
 	)
 	exitCode, err := svc.Exec(ctx, treepad.ExecInput{
 		Branch:  branch,

--- a/internal/commands/exec.go
+++ b/internal/commands/exec.go
@@ -46,7 +46,7 @@ func runExec(ctx context.Context, cmd *cli.Command) error {
 		os.Stdout,
 		os.Stdin,
 	)
-	result, err := svc.Exec(ctx, treepad.ExecInput{
+	exitCode, err := svc.Exec(ctx, treepad.ExecInput{
 		Branch:  branch,
 		Command: command,
 		Args:    cmdArgs,
@@ -54,8 +54,8 @@ func runExec(ctx context.Context, cmd *cli.Command) error {
 	if err != nil {
 		return err
 	}
-	if result.ExitCode != 0 {
-		return cli.Exit("", result.ExitCode)
+	if exitCode != 0 {
+		return cli.Exit("", exitCode)
 	}
 	return nil
 }

--- a/internal/commands/router.go
+++ b/internal/commands/router.go
@@ -13,5 +13,6 @@ func Router() []*cli.Command {
 		statusCommand(),
 		cdCommand(),
 		doctorCommand(),
+		execCommand(),
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,12 +77,25 @@ func (o OpenConfig) IsZero() bool {
 	return len(o.Command) == 0
 }
 
+// ExecConfig controls the task runner used by `tp exec`.
+type ExecConfig struct {
+	// Runner overrides auto-detection. Valid values: just, npm, pnpm, yarn, bun,
+	// make, pip, poetry, uv.
+	Runner string `toml:"runner"`
+}
+
+// IsZero reports whether no exec runner is explicitly configured.
+func (e ExecConfig) IsZero() bool {
+	return e.Runner == ""
+}
+
 // Config is the full resolved configuration for a repo.
 type Config struct {
 	Sync     SyncConfig     `toml:"sync"`
 	Artifact ArtifactConfig `toml:"artifact"`
 	Open     OpenConfig     `toml:"open"`
 	Hooks    hook.Config    `toml:"hooks"`
+	Exec     ExecConfig     `toml:"exec"`
 }
 
 // GlobalConfigPath returns the path to the global config file.
@@ -140,6 +153,9 @@ func Load(repoRoot string) (Config, error) {
 	}
 	if !fileCfg.Hooks.IsZero() {
 		cfg.Hooks = fileCfg.Hooks
+	}
+	if !fileCfg.Exec.IsZero() {
+		cfg.Exec = fileCfg.Exec
 	}
 
 	slog.Debug("loaded .treepad.toml", "dir", repoRoot, "syncFiles", cfg.Sync.Files)

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -1,0 +1,245 @@
+// Package exec detects project task runners and enumerates their scripts.
+package exec
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Runner describes a detected task runner with its script-invocation prefix
+// and the set of known script names.
+type Runner struct {
+	Name      string   // e.g. "just", "pnpm"
+	ScriptCmd []string // prefix before script name, e.g. ["pnpm", "run"]
+	Scripts   []string // enumerated script names (sorted)
+}
+
+// Detect identifies the task runner in worktreePath and returns it.
+// override, if non-empty, forces use of the named runner (from .treepad.toml [exec] runner).
+// Returns an error if multiple runners are detected and override is empty.
+func Detect(worktreePath, override string) (Runner, error) {
+	if override != "" {
+		scripts, err := ListScripts(worktreePath, override)
+		if err != nil {
+			return Runner{}, err
+		}
+		return Runner{
+			Name:      override,
+			ScriptCmd: scriptCmd(override),
+			Scripts:   scripts,
+		}, nil
+	}
+
+	var detected []string
+
+	if hasFile(worktreePath, "justfile") || hasFile(worktreePath, "Justfile") {
+		detected = append(detected, "just")
+	}
+	if hasFile(worktreePath, "package.json") {
+		jsRunner, err := detectJSManager(worktreePath)
+		if err != nil {
+			return Runner{}, err
+		}
+		detected = append(detected, jsRunner)
+	}
+	if hasFile(worktreePath, "Makefile") {
+		detected = append(detected, "make")
+	}
+	if hasFile(worktreePath, "pyproject.toml") {
+		detected = append(detected, detectPythonRunner(worktreePath))
+	}
+
+	if len(detected) == 0 {
+		return Runner{}, fmt.Errorf("no task runner detected; check that a justfile, package.json, Makefile, or pyproject.toml is present")
+	}
+	if len(detected) > 1 {
+		return Runner{}, fmt.Errorf("multiple task runners detected (%s); set [exec]\nrunner = %q (or another) in .treepad.toml to disambiguate", strings.Join(detected, ", "), detected[0])
+	}
+
+	name := detected[0]
+	scripts, err := ListScripts(worktreePath, name)
+	if err != nil {
+		return Runner{}, err
+	}
+	return Runner{
+		Name:      name,
+		ScriptCmd: scriptCmd(name),
+		Scripts:   scripts,
+	}, nil
+}
+
+// ListScripts returns the known script names for the named runner in worktreePath.
+// Returns nil for runners that do not support script enumeration (make, pip).
+func ListScripts(worktreePath, runnerName string) ([]string, error) {
+	switch runnerName {
+	case "just":
+		return listJustRecipes(worktreePath)
+	case "npm", "pnpm", "yarn", "bun":
+		return listPackageJSONScripts(worktreePath)
+	case "poetry", "uv", "pip":
+		return listPyprojectScripts(worktreePath)
+	case "make":
+		return nil, nil
+	default:
+		return nil, nil
+	}
+}
+
+func scriptCmd(runner string) []string {
+	switch runner {
+	case "just":
+		return []string{"just"}
+	case "npm":
+		return []string{"npm", "run"}
+	case "pnpm":
+		return []string{"pnpm", "run"}
+	case "yarn":
+		return []string{"yarn"}
+	case "bun":
+		return []string{"bun", "run"}
+	case "poetry":
+		return []string{"poetry", "run"}
+	case "uv":
+		return []string{"uv", "run"}
+	case "make":
+		return []string{"make"}
+	default:
+		return []string{runner}
+	}
+}
+
+func hasFile(dir, name string) bool {
+	_, err := os.Stat(filepath.Join(dir, name))
+	return err == nil
+}
+
+// detectJSManager selects npm/pnpm/yarn/bun based on lockfile presence,
+// then the packageManager field in package.json, defaulting to npm.
+func detectJSManager(dir string) (string, error) {
+	switch {
+	case hasFile(dir, "bun.lockb"):
+		return "bun", nil
+	case hasFile(dir, "pnpm-lock.yaml"):
+		return "pnpm", nil
+	case hasFile(dir, "yarn.lock"):
+		return "yarn", nil
+	case hasFile(dir, "package-lock.json"):
+		return "npm", nil
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "package.json"))
+	if err != nil {
+		return "npm", nil
+	}
+	var pkg struct {
+		PackageManager string `json:"packageManager"`
+	}
+	if jsonErr := json.Unmarshal(data, &pkg); jsonErr == nil && pkg.PackageManager != "" {
+		name, _, _ := strings.Cut(pkg.PackageManager, "@")
+		switch name {
+		case "npm", "pnpm", "yarn", "bun":
+			return name, nil
+		}
+	}
+	return "npm", nil
+}
+
+// detectPythonRunner picks poetry or uv based on pyproject.toml contents.
+func detectPythonRunner(dir string) string {
+	data, err := os.ReadFile(filepath.Join(dir, "pyproject.toml"))
+	if err != nil {
+		return "uv"
+	}
+	if strings.Contains(string(data), "[tool.poetry]") {
+		return "poetry"
+	}
+	return "uv"
+}
+
+// justRecipeRe matches lines that look like recipe definitions (starts with an
+// identifier then anything up to a colon). Post-filtered to exclude ":="
+// variable assignments since Go's regexp doesn't support negative lookaheads.
+var justRecipeRe = regexp.MustCompile(`(?m)^([a-zA-Z0-9][a-zA-Z0-9_-]*)[^:\n]*:`)
+
+func listJustRecipes(dir string) ([]string, error) {
+	for _, name := range []string{"justfile", "Justfile"} {
+		data, err := os.ReadFile(filepath.Join(dir, name))
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", name, err)
+		}
+		var recipes []string
+		for _, m := range justRecipeRe.FindAllStringSubmatch(string(data), -1) {
+			recipe := m[1]
+			fullMatch := m[0]
+			// Exclude variable assignments (name := value) and private recipes.
+			if strings.Contains(fullMatch, ":=") || strings.HasPrefix(recipe, "_") {
+				continue
+			}
+			recipes = append(recipes, recipe)
+		}
+		sort.Strings(recipes)
+		return recipes, nil
+	}
+	return nil, nil
+}
+
+func listPackageJSONScripts(dir string) ([]string, error) {
+	data, err := os.ReadFile(filepath.Join(dir, "package.json"))
+	if err != nil {
+		return nil, fmt.Errorf("read package.json: %w", err)
+	}
+	var pkg struct {
+		Scripts map[string]string `json:"scripts"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return nil, fmt.Errorf("parse package.json: %w", err)
+	}
+	scripts := make([]string, 0, len(pkg.Scripts))
+	for name := range pkg.Scripts {
+		scripts = append(scripts, name)
+	}
+	sort.Strings(scripts)
+	return scripts, nil
+}
+
+type pyprojectTOML struct {
+	Project struct {
+		Scripts map[string]string `toml:"scripts"`
+	} `toml:"project"`
+	Tool struct {
+		Poetry struct {
+			Scripts map[string]string `toml:"scripts"`
+		} `toml:"poetry"`
+	} `toml:"tool"`
+}
+
+func listPyprojectScripts(dir string) ([]string, error) {
+	data, err := os.ReadFile(filepath.Join(dir, "pyproject.toml"))
+	if err != nil {
+		return nil, fmt.Errorf("read pyproject.toml: %w", err)
+	}
+	var py pyprojectTOML
+	if _, err := toml.Decode(string(data), &py); err != nil {
+		return nil, fmt.Errorf("parse pyproject.toml: %w", err)
+	}
+	scriptMap := py.Project.Scripts
+	if len(scriptMap) == 0 {
+		scriptMap = py.Tool.Poetry.Scripts
+	}
+	scripts := make([]string, 0, len(scriptMap))
+	for name := range scriptMap {
+		scripts = append(scripts, name)
+	}
+	sort.Strings(scripts)
+	return scripts, nil
+}

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -26,7 +26,7 @@ type Runner struct {
 // Returns an error if multiple runners are detected and override is empty.
 func Detect(worktreePath, override string) (Runner, error) {
 	if override != "" {
-		scripts, err := ListScripts(worktreePath, override)
+		scripts, err := listScripts(worktreePath, override)
 		if err != nil {
 			return Runner{}, err
 		}
@@ -64,7 +64,7 @@ func Detect(worktreePath, override string) (Runner, error) {
 	}
 
 	name := detected[0]
-	scripts, err := ListScripts(worktreePath, name)
+	scripts, err := listScripts(worktreePath, name)
 	if err != nil {
 		return Runner{}, err
 	}
@@ -75,9 +75,9 @@ func Detect(worktreePath, override string) (Runner, error) {
 	}, nil
 }
 
-// ListScripts returns the known script names for the named runner in worktreePath.
+// listScripts returns the known script names for the named runner in worktreePath.
 // Returns nil for runners that do not support script enumeration (make, pip).
-func ListScripts(worktreePath, runnerName string) ([]string, error) {
+func listScripts(worktreePath, runnerName string) ([]string, error) {
 	switch runnerName {
 	case "just":
 		return listJustRecipes(worktreePath)

--- a/internal/exec/runner_test.go
+++ b/internal/exec/runner_test.go
@@ -13,172 +13,138 @@ func writeFile(t *testing.T, dir, name, content string) {
 	}
 }
 
-func TestDetect_just(t *testing.T) {
-	dir := t.TempDir()
-	writeFile(t, dir, "justfile", "build:\n  go build ./...\ntest:\n  go test ./...\n_private:\n  echo secret\n")
+func TestDetect(t *testing.T) {
+	tests := []struct {
+		name     string
+		files    map[string]string
+		override string
+		wantName string
+		wantErr  bool
+		// wantScripts, if non-nil, asserts Scripts exactly.
+		wantScripts []string
+		// wantNoScripts asserts Scripts is empty (for make).
+		wantNoScripts bool
+	}{
+		{
+			name: "just",
+			files: map[string]string{
+				"justfile": "build:\n  go build ./...\ntest:\n  go test ./...\n_private:\n  echo secret\n",
+			},
+			wantName:    "just",
+			wantScripts: []string{"build", "test"},
+		},
+		{
+			name: "justfile capitalised",
+			files: map[string]string{
+				"Justfile": "lint:\n  golangci-lint run\n",
+			},
+			wantName: "just",
+		},
+		{
+			name: "package.json with bun lockfile",
+			files: map[string]string{
+				"package.json": `{"scripts":{"dev":"vite","build":"vite build"}}`,
+				"bun.lockb":    "",
+			},
+			wantName:    "bun",
+			wantScripts: []string{"build", "dev"},
+		},
+		{
+			name: "package.json with pnpm lockfile",
+			files: map[string]string{
+				"package.json":   `{"scripts":{"start":"node index.js"}}`,
+				"pnpm-lock.yaml": "",
+			},
+			wantName: "pnpm",
+		},
+		{
+			name: "package.json with packageManager field",
+			files: map[string]string{
+				"package.json": `{"packageManager":"yarn@4.0.0","scripts":{"build":"tsc"}}`,
+			},
+			wantName: "yarn",
+		},
+		{
+			name: "package.json defaults to npm",
+			files: map[string]string{
+				"package.json": `{"scripts":{"test":"jest"}}`,
+			},
+			wantName: "npm",
+		},
+		{
+			name: "pyproject.toml poetry",
+			files: map[string]string{
+				"pyproject.toml": "[tool.poetry]\nname = \"myapp\"\n\n[tool.poetry.scripts]\nmyapp = \"myapp.cli:main\"\n",
+			},
+			wantName:    "poetry",
+			wantScripts: []string{"myapp"},
+		},
+		{
+			name: "pyproject.toml uv",
+			files: map[string]string{
+				"pyproject.toml": "[project]\nname = \"myapp\"\n\n[project.scripts]\nrun = \"myapp.main:main\"\n",
+			},
+			wantName: "uv",
+		},
+		{
+			name: "make",
+			files: map[string]string{
+				"Makefile": "build:\n\tgo build ./...\n",
+			},
+			wantName:      "make",
+			wantNoScripts: true,
+		},
+		{
+			name: "ambiguous runners error",
+			files: map[string]string{
+				"justfile":     "build:\n  go build\n",
+				"package.json": `{"scripts":{"build":"tsc"}}`,
+			},
+			wantErr: true,
+		},
+		{
+			name:    "no runner found error",
+			files:   map[string]string{},
+			wantErr: true,
+		},
+		{
+			name: "override selects runner despite ambiguity",
+			files: map[string]string{
+				"package.json": `{"scripts":{"test":"jest"}}`,
+				"justfile":     "check:\n  go vet ./...\n",
+			},
+			override: "just",
+			wantName: "just",
+		},
+	}
 
-	r, err := Detect(dir, "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if r.Name != "just" {
-		t.Errorf("Name = %q, want %q", r.Name, "just")
-	}
-	want := []string{"build", "test"}
-	if !equalStrSlice(r.Scripts, want) {
-		t.Errorf("Scripts = %v, want %v", r.Scripts, want)
-	}
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for name, content := range tt.files {
+				writeFile(t, dir, name, content)
+			}
 
-func TestDetect_justfileCapitalised(t *testing.T) {
-	dir := t.TempDir()
-	writeFile(t, dir, "Justfile", "lint:\n  golangci-lint run\n")
-
-	r, err := Detect(dir, "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if r.Name != "just" {
-		t.Errorf("Name = %q, want %q", r.Name, "just")
-	}
-}
-
-func TestDetect_packageJSON_lockfileBun(t *testing.T) {
-	dir := t.TempDir()
-	writeFile(t, dir, "package.json", `{"scripts":{"dev":"vite","build":"vite build"}}`)
-	writeFile(t, dir, "bun.lockb", "")
-
-	r, err := Detect(dir, "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if r.Name != "bun" {
-		t.Errorf("Name = %q, want %q", r.Name, "bun")
-	}
-	want := []string{"build", "dev"}
-	if !equalStrSlice(r.Scripts, want) {
-		t.Errorf("Scripts = %v, want %v", r.Scripts, want)
-	}
-}
-
-func TestDetect_packageJSON_lockfilePnpm(t *testing.T) {
-	dir := t.TempDir()
-	writeFile(t, dir, "package.json", `{"scripts":{"start":"node index.js"}}`)
-	writeFile(t, dir, "pnpm-lock.yaml", "")
-
-	r, err := Detect(dir, "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if r.Name != "pnpm" {
-		t.Errorf("Name = %q, want %q", r.Name, "pnpm")
-	}
-}
-
-func TestDetect_packageJSON_packageManagerField(t *testing.T) {
-	dir := t.TempDir()
-	writeFile(t, dir, "package.json", `{"packageManager":"yarn@4.0.0","scripts":{"build":"tsc"}}`)
-
-	r, err := Detect(dir, "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if r.Name != "yarn" {
-		t.Errorf("Name = %q, want %q", r.Name, "yarn")
-	}
-}
-
-func TestDetect_packageJSON_defaultNPM(t *testing.T) {
-	dir := t.TempDir()
-	writeFile(t, dir, "package.json", `{"scripts":{"test":"jest"}}`)
-
-	r, err := Detect(dir, "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if r.Name != "npm" {
-		t.Errorf("Name = %q, want %q", r.Name, "npm")
-	}
-}
-
-func TestDetect_pyprojectPoetry(t *testing.T) {
-	dir := t.TempDir()
-	writeFile(t, dir, "pyproject.toml", "[tool.poetry]\nname = \"myapp\"\n\n[tool.poetry.scripts]\nmyapp = \"myapp.cli:main\"\n")
-
-	r, err := Detect(dir, "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if r.Name != "poetry" {
-		t.Errorf("Name = %q, want %q", r.Name, "poetry")
-	}
-	want := []string{"myapp"}
-	if !equalStrSlice(r.Scripts, want) {
-		t.Errorf("Scripts = %v, want %v", r.Scripts, want)
-	}
-}
-
-func TestDetect_pyprojectUV(t *testing.T) {
-	dir := t.TempDir()
-	writeFile(t, dir, "pyproject.toml", "[project]\nname = \"myapp\"\n\n[project.scripts]\nrun = \"myapp.main:main\"\n")
-
-	r, err := Detect(dir, "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if r.Name != "uv" {
-		t.Errorf("Name = %q, want %q", r.Name, "uv")
-	}
-}
-
-func TestDetect_make(t *testing.T) {
-	dir := t.TempDir()
-	writeFile(t, dir, "Makefile", "build:\n\tgo build ./...\n")
-
-	r, err := Detect(dir, "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if r.Name != "make" {
-		t.Errorf("Name = %q, want %q", r.Name, "make")
-	}
-	if len(r.Scripts) != 0 {
-		t.Errorf("make Scripts should be empty, got %v", r.Scripts)
-	}
-}
-
-func TestDetect_ambiguous_error(t *testing.T) {
-	dir := t.TempDir()
-	writeFile(t, dir, "justfile", "build:\n  go build\n")
-	writeFile(t, dir, "package.json", `{"scripts":{"build":"tsc"}}`)
-
-	_, err := Detect(dir, "")
-	if err == nil {
-		t.Fatal("expected error for ambiguous runners")
-	}
-}
-
-func TestDetect_noneFound_error(t *testing.T) {
-	dir := t.TempDir()
-
-	_, err := Detect(dir, "")
-	if err == nil {
-		t.Fatal("expected error when no runners detected")
-	}
-}
-
-func TestDetect_override(t *testing.T) {
-	dir := t.TempDir()
-	// Has package.json but we force just via override
-	writeFile(t, dir, "package.json", `{"scripts":{"test":"jest"}}`)
-	writeFile(t, dir, "justfile", "check:\n  go vet ./...\n")
-
-	r, err := Detect(dir, "just")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if r.Name != "just" {
-		t.Errorf("Name = %q, want %q", r.Name, "just")
+			r, err := Detect(dir, tt.override)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if r.Name != tt.wantName {
+				t.Errorf("Name = %q, want %q", r.Name, tt.wantName)
+			}
+			if tt.wantScripts != nil && !equalStrSlice(r.Scripts, tt.wantScripts) {
+				t.Errorf("Scripts = %v, want %v", r.Scripts, tt.wantScripts)
+			}
+			if tt.wantNoScripts && len(r.Scripts) != 0 {
+				t.Errorf("Scripts should be empty, got %v", r.Scripts)
+			}
+		})
 	}
 }
 
@@ -186,7 +152,7 @@ func TestListScripts_justRecipeWithArgs(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "justfile", "build target='debug':\n  go build -tags {{target}}\ntest:\n  go test\n")
 
-	scripts, err := ListScripts(dir, "just")
+	scripts, err := listScripts(dir, "just")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -197,7 +163,7 @@ func TestListScripts_justRecipeWithArgs(t *testing.T) {
 }
 
 func TestScriptCmd(t *testing.T) {
-	cases := []struct {
+	tests := []struct {
 		runner string
 		want   []string
 	}{
@@ -210,11 +176,13 @@ func TestScriptCmd(t *testing.T) {
 		{"uv", []string{"uv", "run"}},
 		{"make", []string{"make"}},
 	}
-	for _, tc := range cases {
-		got := scriptCmd(tc.runner)
-		if !equalStrSlice(got, tc.want) {
-			t.Errorf("scriptCmd(%q) = %v, want %v", tc.runner, got, tc.want)
-		}
+	for _, tt := range tests {
+		t.Run(tt.runner, func(t *testing.T) {
+			got := scriptCmd(tt.runner)
+			if !equalStrSlice(got, tt.want) {
+				t.Errorf("scriptCmd(%q) = %v, want %v", tt.runner, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/exec/runner_test.go
+++ b/internal/exec/runner_test.go
@@ -1,0 +1,231 @@
+package exec
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func TestDetect_just(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "justfile", "build:\n  go build ./...\ntest:\n  go test ./...\n_private:\n  echo secret\n")
+
+	r, err := Detect(dir, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.Name != "just" {
+		t.Errorf("Name = %q, want %q", r.Name, "just")
+	}
+	want := []string{"build", "test"}
+	if !equalStrSlice(r.Scripts, want) {
+		t.Errorf("Scripts = %v, want %v", r.Scripts, want)
+	}
+}
+
+func TestDetect_justfileCapitalised(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "Justfile", "lint:\n  golangci-lint run\n")
+
+	r, err := Detect(dir, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.Name != "just" {
+		t.Errorf("Name = %q, want %q", r.Name, "just")
+	}
+}
+
+func TestDetect_packageJSON_lockfileBun(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "package.json", `{"scripts":{"dev":"vite","build":"vite build"}}`)
+	writeFile(t, dir, "bun.lockb", "")
+
+	r, err := Detect(dir, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.Name != "bun" {
+		t.Errorf("Name = %q, want %q", r.Name, "bun")
+	}
+	want := []string{"build", "dev"}
+	if !equalStrSlice(r.Scripts, want) {
+		t.Errorf("Scripts = %v, want %v", r.Scripts, want)
+	}
+}
+
+func TestDetect_packageJSON_lockfilePnpm(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "package.json", `{"scripts":{"start":"node index.js"}}`)
+	writeFile(t, dir, "pnpm-lock.yaml", "")
+
+	r, err := Detect(dir, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.Name != "pnpm" {
+		t.Errorf("Name = %q, want %q", r.Name, "pnpm")
+	}
+}
+
+func TestDetect_packageJSON_packageManagerField(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "package.json", `{"packageManager":"yarn@4.0.0","scripts":{"build":"tsc"}}`)
+
+	r, err := Detect(dir, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.Name != "yarn" {
+		t.Errorf("Name = %q, want %q", r.Name, "yarn")
+	}
+}
+
+func TestDetect_packageJSON_defaultNPM(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "package.json", `{"scripts":{"test":"jest"}}`)
+
+	r, err := Detect(dir, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.Name != "npm" {
+		t.Errorf("Name = %q, want %q", r.Name, "npm")
+	}
+}
+
+func TestDetect_pyprojectPoetry(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "pyproject.toml", "[tool.poetry]\nname = \"myapp\"\n\n[tool.poetry.scripts]\nmyapp = \"myapp.cli:main\"\n")
+
+	r, err := Detect(dir, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.Name != "poetry" {
+		t.Errorf("Name = %q, want %q", r.Name, "poetry")
+	}
+	want := []string{"myapp"}
+	if !equalStrSlice(r.Scripts, want) {
+		t.Errorf("Scripts = %v, want %v", r.Scripts, want)
+	}
+}
+
+func TestDetect_pyprojectUV(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "pyproject.toml", "[project]\nname = \"myapp\"\n\n[project.scripts]\nrun = \"myapp.main:main\"\n")
+
+	r, err := Detect(dir, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.Name != "uv" {
+		t.Errorf("Name = %q, want %q", r.Name, "uv")
+	}
+}
+
+func TestDetect_make(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "Makefile", "build:\n\tgo build ./...\n")
+
+	r, err := Detect(dir, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.Name != "make" {
+		t.Errorf("Name = %q, want %q", r.Name, "make")
+	}
+	if len(r.Scripts) != 0 {
+		t.Errorf("make Scripts should be empty, got %v", r.Scripts)
+	}
+}
+
+func TestDetect_ambiguous_error(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "justfile", "build:\n  go build\n")
+	writeFile(t, dir, "package.json", `{"scripts":{"build":"tsc"}}`)
+
+	_, err := Detect(dir, "")
+	if err == nil {
+		t.Fatal("expected error for ambiguous runners")
+	}
+}
+
+func TestDetect_noneFound_error(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := Detect(dir, "")
+	if err == nil {
+		t.Fatal("expected error when no runners detected")
+	}
+}
+
+func TestDetect_override(t *testing.T) {
+	dir := t.TempDir()
+	// Has package.json but we force just via override
+	writeFile(t, dir, "package.json", `{"scripts":{"test":"jest"}}`)
+	writeFile(t, dir, "justfile", "check:\n  go vet ./...\n")
+
+	r, err := Detect(dir, "just")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.Name != "just" {
+		t.Errorf("Name = %q, want %q", r.Name, "just")
+	}
+}
+
+func TestListScripts_justRecipeWithArgs(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "justfile", "build target='debug':\n  go build -tags {{target}}\ntest:\n  go test\n")
+
+	scripts, err := ListScripts(dir, "just")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"build", "test"}
+	if !equalStrSlice(scripts, want) {
+		t.Errorf("Scripts = %v, want %v", scripts, want)
+	}
+}
+
+func TestScriptCmd(t *testing.T) {
+	cases := []struct {
+		runner string
+		want   []string
+	}{
+		{"just", []string{"just"}},
+		{"npm", []string{"npm", "run"}},
+		{"pnpm", []string{"pnpm", "run"}},
+		{"yarn", []string{"yarn"}},
+		{"bun", []string{"bun", "run"}},
+		{"poetry", []string{"poetry", "run"}},
+		{"uv", []string{"uv", "run"}},
+		{"make", []string{"make"}},
+	}
+	for _, tc := range cases {
+		got := scriptCmd(tc.runner)
+		if !equalStrSlice(got, tc.want) {
+			t.Errorf("scriptCmd(%q) = %v, want %v", tc.runner, got, tc.want)
+		}
+	}
+}
+
+func equalStrSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/treepad/service_exec.go
+++ b/internal/treepad/service_exec.go
@@ -17,13 +17,12 @@ import (
 // calling process. Returns the child's exit code (non-zero does not produce an
 // error; a non-nil error indicates a launch failure such as binary not found).
 type PassthroughRunner interface {
-	Run(ctx context.Context, dir, name string, args ...string) (exitCode int, err error)
+	Run(ctx context.Context, dir, name string, args ...string) (int, error)
 }
 
-// OSPassthroughRunner is the real PassthroughRunner that uses os/exec.
-type OSPassthroughRunner struct{}
+type osPassthroughRunner struct{}
 
-func (OSPassthroughRunner) Run(ctx context.Context, dir, name string, args ...string) (int, error) {
+func (osPassthroughRunner) Run(ctx context.Context, dir, name string, args ...string) (int, error) {
 	cmd := osexec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir
 	cmd.Stdin = os.Stdin
@@ -50,29 +49,25 @@ type ExecInput struct {
 	Runner PassthroughRunner
 }
 
-// ExecResult carries the child process exit code.
-type ExecResult struct {
-	ExitCode int
-}
-
 // Exec runs a command in the named worktree, routing through the detected task
-// runner when the command matches a known script.
-func (s *Service) Exec(ctx context.Context, in ExecInput) (ExecResult, error) {
+// runner when the command matches a known script. Returns the child process exit
+// code (non-zero does not produce an error).
+func (s *Service) Exec(ctx context.Context, in ExecInput) (int, error) {
 	worktrees, err := s.listWorktrees(ctx)
 	if err != nil {
-		return ExecResult{}, err
+		return 0, err
 	}
 
 	wt, ok := worktree.FindByBranch(worktrees, in.Branch)
 	if !ok {
-		return ExecResult{}, fmt.Errorf("no worktree found for branch %q; run `tp workspace` to list worktrees", in.Branch)
+		return 0, fmt.Errorf("no worktree found for branch %q; run `tp workspace` to list worktrees", in.Branch)
 	}
 
 	cwd := in.Cwd
 	if cwd == "" {
 		cwd, err = os.Getwd()
 		if err != nil {
-			return ExecResult{}, fmt.Errorf("get current directory: %w", err)
+			return 0, fmt.Errorf("get current directory: %w", err)
 		}
 	}
 	if filepath.Clean(wt.Path) == filepath.Clean(cwd) {
@@ -81,30 +76,26 @@ func (s *Service) Exec(ctx context.Context, in ExecInput) (ExecResult, error) {
 
 	cfg, err := config.Load(wt.Path)
 	if err != nil {
-		return ExecResult{}, fmt.Errorf("load config: %w", err)
+		return 0, fmt.Errorf("load config: %w", err)
 	}
 
 	runner, err := tpexec.Detect(wt.Path, cfg.Exec.Runner)
 	if err != nil {
-		return ExecResult{}, err
+		return 0, err
 	}
 
 	if in.Command == "" {
 		s.printScripts(runner)
-		return ExecResult{}, nil
+		return 0, nil
 	}
 
 	name, args := s.buildCommand(runner, in.Command, in.Args)
 
 	pt := in.Runner
 	if pt == nil {
-		pt = OSPassthroughRunner{}
+		pt = osPassthroughRunner{}
 	}
-	exitCode, err := pt.Run(ctx, wt.Path, name, args...)
-	if err != nil {
-		return ExecResult{}, err
-	}
-	return ExecResult{ExitCode: exitCode}, nil
+	return pt.Run(ctx, wt.Path, name, args...)
 }
 
 func (s *Service) printScripts(runner tpexec.Runner) {

--- a/internal/treepad/service_exec.go
+++ b/internal/treepad/service_exec.go
@@ -1,0 +1,142 @@
+package treepad
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	osexec "os/exec"
+	"path/filepath"
+
+	"treepad/internal/config"
+	tpexec "treepad/internal/exec"
+	"treepad/internal/worktree"
+)
+
+// PassthroughRunner executes a command in dir with stdio inherited from the
+// calling process. Returns the child's exit code (non-zero does not produce an
+// error; a non-nil error indicates a launch failure such as binary not found).
+type PassthroughRunner interface {
+	Run(ctx context.Context, dir, name string, args ...string) (exitCode int, err error)
+}
+
+// OSPassthroughRunner is the real PassthroughRunner that uses os/exec.
+type OSPassthroughRunner struct{}
+
+func (OSPassthroughRunner) Run(ctx context.Context, dir, name string, args ...string) (int, error) {
+	cmd := osexec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		var exitErr *osexec.ExitError
+		if errors.As(err, &exitErr) {
+			return exitErr.ExitCode(), nil
+		}
+		return 1, err
+	}
+	return 0, nil
+}
+
+// ExecInput parameterises a tp exec invocation.
+type ExecInput struct {
+	Branch  string
+	Command string
+	Args    []string
+	// Cwd overrides os.Getwd for the same-worktree warning. Empty means use os.Getwd.
+	Cwd string
+	// Runner overrides OSPassthroughRunner for testing.
+	Runner PassthroughRunner
+}
+
+// ExecResult carries the child process exit code.
+type ExecResult struct {
+	ExitCode int
+}
+
+// Exec runs a command in the named worktree, routing through the detected task
+// runner when the command matches a known script.
+func (s *Service) Exec(ctx context.Context, in ExecInput) (ExecResult, error) {
+	worktrees, err := s.listWorktrees(ctx)
+	if err != nil {
+		return ExecResult{}, err
+	}
+
+	wt, ok := worktree.FindByBranch(worktrees, in.Branch)
+	if !ok {
+		return ExecResult{}, fmt.Errorf("no worktree found for branch %q; run `tp workspace` to list worktrees", in.Branch)
+	}
+
+	cwd := in.Cwd
+	if cwd == "" {
+		cwd, err = os.Getwd()
+		if err != nil {
+			return ExecResult{}, fmt.Errorf("get current directory: %w", err)
+		}
+	}
+	if filepath.Clean(wt.Path) == filepath.Clean(cwd) {
+		_, _ = fmt.Fprintln(s.out, "warning: already in this worktree; consider invoking the runner directly")
+	}
+
+	cfg, err := config.Load(wt.Path)
+	if err != nil {
+		return ExecResult{}, fmt.Errorf("load config: %w", err)
+	}
+
+	runner, err := tpexec.Detect(wt.Path, cfg.Exec.Runner)
+	if err != nil {
+		return ExecResult{}, err
+	}
+
+	if in.Command == "" {
+		s.printScripts(runner)
+		return ExecResult{}, nil
+	}
+
+	name, args := s.buildCommand(runner, in.Command, in.Args)
+
+	pt := in.Runner
+	if pt == nil {
+		pt = OSPassthroughRunner{}
+	}
+	exitCode, err := pt.Run(ctx, wt.Path, name, args...)
+	if err != nil {
+		return ExecResult{}, err
+	}
+	return ExecResult{ExitCode: exitCode}, nil
+}
+
+func (s *Service) printScripts(runner tpexec.Runner) {
+	_, _ = fmt.Fprintf(s.out, "Runner: %s\n", runner.Name)
+	if len(runner.Scripts) == 0 {
+		_, _ = fmt.Fprintln(s.out, "Scripts: (none)")
+		return
+	}
+	_, _ = fmt.Fprintln(s.out, "Scripts:")
+	for _, sc := range runner.Scripts {
+		_, _ = fmt.Fprintf(s.out, "  %s\n", sc)
+	}
+}
+
+// buildCommand returns the executable name and arguments for the given command,
+// routing through the runner when the command matches an enumerated script.
+func (s *Service) buildCommand(runner tpexec.Runner, command string, extraArgs []string) (string, []string) {
+	scriptSet := make(map[string]bool, len(runner.Scripts))
+	for _, sc := range runner.Scripts {
+		scriptSet[sc] = true
+	}
+
+	if !scriptSet[command] {
+		return command, extraArgs
+	}
+
+	// Build: <ScriptCmd...> <command> [-- for npm] <extraArgs...>
+	full := append(append([]string{}, runner.ScriptCmd...), command)
+	if runner.Name == "npm" && len(extraArgs) > 0 {
+		full = append(full, "--")
+	}
+	full = append(full, extraArgs...)
+
+	return full[0], full[1:]
+}

--- a/internal/treepad/service_exec_test.go
+++ b/internal/treepad/service_exec_test.go
@@ -104,9 +104,9 @@ func TestExec_dispatch(t *testing.T) {
 			wantOutput:   []string{"warning"},
 		},
 		{
-			name:    "no command lists detected runner and scripts",
-			files:   map[string]string{"justfile": "build:\n  go build\ntest:\n  go test\n"},
-			command: "",
+			name:       "no command lists detected runner and scripts",
+			files:      map[string]string{"justfile": "build:\n  go build\ntest:\n  go test\n"},
+			command:    "",
 			wantOutput: []string{"Runner: just", "build", "test"},
 		},
 		{

--- a/internal/treepad/service_exec_test.go
+++ b/internal/treepad/service_exec_test.go
@@ -3,6 +3,7 @@ package treepad
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,7 +30,7 @@ func (f *fakePassthroughRunner) Run(_ context.Context, dir, name string, args ..
 
 // worktreePorcelainWithPath builds porcelain output with a controllable path.
 func worktreePorcelainWithPath(branch, path string) []byte {
-	return []byte("worktree " + path + "\nHEAD abc123\nbranch refs/heads/" + branch + "\n\n")
+	return fmt.Appendf(nil, "worktree %s\nHEAD abc123\nbranch refs/heads/%s\n\n", path, branch)
 }
 
 func TestExec_unknownBranch(t *testing.T) {
@@ -48,7 +49,7 @@ func TestExec_unknownBranch(t *testing.T) {
 func TestExec_scriptDispatch(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "justfile"), []byte("build:\n  go build ./...\n"), 0o644); err != nil {
-		t.Fatal(err)
+		t.Fatalf("write justfile: %v", err)
 	}
 
 	porcelain := worktreePorcelainWithPath("feat", dir)
@@ -56,7 +57,7 @@ func TestExec_scriptDispatch(t *testing.T) {
 	var out bytes.Buffer
 	svc := NewService(fakeRunner{output: porcelain}, &fakeSyncer{}, nil, &fakeHookRunner{}, &out, strings.NewReader(""))
 
-	result, err := svc.Exec(context.Background(), ExecInput{
+	exitCode, err := svc.Exec(context.Background(), ExecInput{
 		Branch:  "feat",
 		Command: "build",
 		Args:    []string{"--verbose"},
@@ -66,8 +67,8 @@ func TestExec_scriptDispatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result.ExitCode != 0 {
-		t.Errorf("ExitCode = %d, want 0", result.ExitCode)
+	if exitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", exitCode)
 	}
 	if len(pt.calls) != 1 {
 		t.Fatalf("want 1 call, got %d", len(pt.calls))
@@ -88,7 +89,7 @@ func TestExec_scriptDispatch(t *testing.T) {
 func TestExec_rawFallback(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "justfile"), []byte("build:\n  go build ./...\n"), 0o644); err != nil {
-		t.Fatal(err)
+		t.Fatalf("write justfile: %v", err)
 	}
 
 	porcelain := worktreePorcelainWithPath("feat", dir)
@@ -118,69 +119,68 @@ func TestExec_rawFallback(t *testing.T) {
 	}
 }
 
-func TestExec_npmArgsDoubleDash(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"scripts":{"test":"jest"}}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "package-lock.json"), []byte("{}"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	porcelain := worktreePorcelainWithPath("feat", dir)
-	pt := &fakePassthroughRunner{}
-	svc := NewService(fakeRunner{output: porcelain}, &fakeSyncer{}, nil, &fakeHookRunner{}, &bytes.Buffer{}, strings.NewReader(""))
-
-	_, err := svc.Exec(context.Background(), ExecInput{
-		Branch:  "feat",
-		Command: "test",
-		Args:    []string{"--watch"},
-		Cwd:     "/some/other",
-		Runner:  pt,
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	call := pt.calls[0]
-	wantArgs := []string{"run", "test", "--", "--watch"}
-	if !equalStringSlice(call.args, wantArgs) {
-		t.Errorf("args = %v, want %v", call.args, wantArgs)
-	}
-}
-
-func TestExec_npmNoDoubleDashWithoutArgs(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"scripts":{"build":"tsc"}}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "package-lock.json"), []byte("{}"), 0o644); err != nil {
-		t.Fatal(err)
+func TestExec_npmArgs(t *testing.T) {
+	tests := []struct {
+		name        string
+		packageJSON string
+		command     string
+		args        []string
+		wantArgs    []string
+	}{
+		{
+			name:        "double dash injected when args present",
+			packageJSON: `{"scripts":{"test":"jest"}}`,
+			command:     "test",
+			args:        []string{"--watch"},
+			wantArgs:    []string{"run", "test", "--", "--watch"},
+		},
+		{
+			name:        "no double dash when no args",
+			packageJSON: `{"scripts":{"build":"tsc"}}`,
+			command:     "build",
+			args:        nil,
+			wantArgs:    []string{"run", "build"},
+		},
 	}
 
-	porcelain := worktreePorcelainWithPath("feat", dir)
-	pt := &fakePassthroughRunner{}
-	svc := NewService(fakeRunner{output: porcelain}, &fakeSyncer{}, nil, &fakeHookRunner{}, &bytes.Buffer{}, strings.NewReader(""))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(tt.packageJSON), 0o644); err != nil {
+				t.Fatalf("write package.json: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "package-lock.json"), []byte("{}"), 0o644); err != nil {
+				t.Fatalf("write package-lock.json: %v", err)
+			}
 
-	_, err := svc.Exec(context.Background(), ExecInput{
-		Branch:  "feat",
-		Command: "build",
-		Cwd:     "/some/other",
-		Runner:  pt,
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	call := pt.calls[0]
-	wantArgs := []string{"run", "build"}
-	if !equalStringSlice(call.args, wantArgs) {
-		t.Errorf("args = %v, want %v", call.args, wantArgs)
+			porcelain := worktreePorcelainWithPath("feat", dir)
+			pt := &fakePassthroughRunner{}
+			svc := NewService(fakeRunner{output: porcelain}, &fakeSyncer{}, nil, &fakeHookRunner{}, &bytes.Buffer{}, strings.NewReader(""))
+
+			_, err := svc.Exec(context.Background(), ExecInput{
+				Branch:  "feat",
+				Command: tt.command,
+				Args:    tt.args,
+				Cwd:     "/some/other",
+				Runner:  pt,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(pt.calls) == 0 {
+				t.Fatal("expected a call")
+			}
+			if !equalStringSlice(pt.calls[0].args, tt.wantArgs) {
+				t.Errorf("args = %v, want %v", pt.calls[0].args, tt.wantArgs)
+			}
+		})
 	}
 }
 
 func TestExec_zeroArgListsScripts(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "justfile"), []byte("build:\n  go build\ntest:\n  go test\n"), 0o644); err != nil {
-		t.Fatal(err)
+		t.Fatalf("write justfile: %v", err)
 	}
 
 	porcelain := worktreePorcelainWithPath("feat", dir)
@@ -188,7 +188,7 @@ func TestExec_zeroArgListsScripts(t *testing.T) {
 	var out bytes.Buffer
 	svc := NewService(fakeRunner{output: porcelain}, &fakeSyncer{}, nil, &fakeHookRunner{}, &out, strings.NewReader(""))
 
-	result, err := svc.Exec(context.Background(), ExecInput{
+	exitCode, err := svc.Exec(context.Background(), ExecInput{
 		Branch: "feat",
 		Cwd:    "/some/other",
 		Runner: pt,
@@ -196,8 +196,8 @@ func TestExec_zeroArgListsScripts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result.ExitCode != 0 {
-		t.Errorf("ExitCode = %d, want 0", result.ExitCode)
+	if exitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", exitCode)
 	}
 	if len(pt.calls) != 0 {
 		t.Errorf("expected no exec calls, got %d", len(pt.calls))
@@ -214,7 +214,7 @@ func TestExec_zeroArgListsScripts(t *testing.T) {
 func TestExec_sameWorktreeWarns(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "justfile"), []byte("build:\n  go build\n"), 0o644); err != nil {
-		t.Fatal(err)
+		t.Fatalf("write justfile: %v", err)
 	}
 
 	porcelain := worktreePorcelainWithPath("feat", dir)
@@ -239,14 +239,14 @@ func TestExec_sameWorktreeWarns(t *testing.T) {
 func TestExec_exitCodePropagated(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "justfile"), []byte("fail:\n  exit 1\n"), 0o644); err != nil {
-		t.Fatal(err)
+		t.Fatalf("write justfile: %v", err)
 	}
 
 	porcelain := worktreePorcelainWithPath("feat", dir)
 	pt := &fakePassthroughRunner{exitCode: 42}
 	svc := NewService(fakeRunner{output: porcelain}, &fakeSyncer{}, nil, &fakeHookRunner{}, &bytes.Buffer{}, strings.NewReader(""))
 
-	result, err := svc.Exec(context.Background(), ExecInput{
+	exitCode, err := svc.Exec(context.Background(), ExecInput{
 		Branch:  "feat",
 		Command: "ls", // raw exec, exitCode still comes from fake
 		Cwd:     "/some/other",
@@ -255,8 +255,8 @@ func TestExec_exitCodePropagated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result.ExitCode != 42 {
-		t.Errorf("ExitCode = %d, want 42", result.ExitCode)
+	if exitCode != 42 {
+		t.Errorf("ExitCode = %d, want 42", exitCode)
 	}
 }
 
@@ -264,13 +264,13 @@ func TestExec_configOverrideRunner(t *testing.T) {
 	dir := t.TempDir()
 	// Has package.json but .treepad.toml says runner=just
 	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"scripts":{"start":"node"}}`), 0o644); err != nil {
-		t.Fatal(err)
+		t.Fatalf("write package.json: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, "justfile"), []byte("build:\n  go build\n"), 0o644); err != nil {
-		t.Fatal(err)
+		t.Fatalf("write justfile: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, ".treepad.toml"), []byte("[exec]\nrunner = \"just\"\n"), 0o644); err != nil {
-		t.Fatal(err)
+		t.Fatalf("write .treepad.toml: %v", err)
 	}
 
 	porcelain := worktreePorcelainWithPath("feat", dir)

--- a/internal/treepad/service_exec_test.go
+++ b/internal/treepad/service_exec_test.go
@@ -46,251 +46,143 @@ func TestExec_unknownBranch(t *testing.T) {
 	}
 }
 
-func TestExec_scriptDispatch(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "justfile"), []byte("build:\n  go build ./...\n"), 0o644); err != nil {
-		t.Fatalf("write justfile: %v", err)
-	}
-
-	porcelain := worktreePorcelainWithPath("feat", dir)
-	pt := &fakePassthroughRunner{}
-	var out bytes.Buffer
-	svc := NewService(fakeRunner{output: porcelain}, &fakeSyncer{}, nil, &fakeHookRunner{}, &out, strings.NewReader(""))
-
-	exitCode, err := svc.Exec(context.Background(), ExecInput{
-		Branch:  "feat",
-		Command: "build",
-		Args:    []string{"--verbose"},
-		Cwd:     "/some/other",
-		Runner:  pt,
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if exitCode != 0 {
-		t.Errorf("ExitCode = %d, want 0", exitCode)
-	}
-	if len(pt.calls) != 1 {
-		t.Fatalf("want 1 call, got %d", len(pt.calls))
-	}
-	call := pt.calls[0]
-	if call.name != "just" {
-		t.Errorf("name = %q, want %q", call.name, "just")
-	}
-	wantArgs := []string{"build", "--verbose"}
-	if !equalStringSlice(call.args, wantArgs) {
-		t.Errorf("args = %v, want %v", call.args, wantArgs)
-	}
-	if call.dir != dir {
-		t.Errorf("dir = %q, want %q", call.dir, dir)
-	}
-}
-
-func TestExec_rawFallback(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "justfile"), []byte("build:\n  go build ./...\n"), 0o644); err != nil {
-		t.Fatalf("write justfile: %v", err)
-	}
-
-	porcelain := worktreePorcelainWithPath("feat", dir)
-	pt := &fakePassthroughRunner{}
-	svc := NewService(fakeRunner{output: porcelain}, &fakeSyncer{}, nil, &fakeHookRunner{}, &bytes.Buffer{}, strings.NewReader(""))
-
-	_, err := svc.Exec(context.Background(), ExecInput{
-		Branch:  "feat",
-		Command: "ls",
-		Args:    []string{"-la"},
-		Cwd:     "/some/other",
-		Runner:  pt,
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(pt.calls) != 1 {
-		t.Fatalf("want 1 call, got %d", len(pt.calls))
-	}
-	call := pt.calls[0]
-	if call.name != "ls" {
-		t.Errorf("name = %q, want %q", call.name, "ls")
-	}
-	wantArgs := []string{"-la"}
-	if !equalStringSlice(call.args, wantArgs) {
-		t.Errorf("args = %v, want %v", call.args, wantArgs)
-	}
-}
-
-func TestExec_npmArgs(t *testing.T) {
+func TestExec_dispatch(t *testing.T) {
 	tests := []struct {
-		name        string
-		packageJSON string
-		command     string
-		args        []string
-		wantArgs    []string
+		name         string
+		files        map[string]string // filename → content written to worktree dir
+		command      string
+		args         []string
+		cwdSame      bool // true: set Cwd = worktree dir (triggers same-worktree warning)
+		fakeExitCode int
+		wantExitCode int
+		wantCallName string   // "" means no exec call expected
+		wantCallArgs []string // checked only when wantCallName is set
+		wantOutput   []string // substrings expected in stdout
 	}{
 		{
-			name:        "double dash injected when args present",
-			packageJSON: `{"scripts":{"test":"jest"}}`,
-			command:     "test",
-			args:        []string{"--watch"},
-			wantArgs:    []string{"run", "test", "--", "--watch"},
+			name:         "script routed through just",
+			files:        map[string]string{"justfile": "build:\n  go build ./...\n"},
+			command:      "build",
+			args:         []string{"--verbose"},
+			wantCallName: "just",
+			wantCallArgs: []string{"build", "--verbose"},
 		},
 		{
-			name:        "no double dash when no args",
-			packageJSON: `{"scripts":{"build":"tsc"}}`,
-			command:     "build",
-			args:        nil,
-			wantArgs:    []string{"run", "build"},
+			name:         "unknown command falls back to raw exec",
+			files:        map[string]string{"justfile": "build:\n  go build ./...\n"},
+			command:      "ls",
+			args:         []string{"-la"},
+			wantCallName: "ls",
+			wantCallArgs: []string{"-la"},
+		},
+		{
+			name:         "exit code propagated from child process",
+			files:        map[string]string{"justfile": "fail:\n  exit 1\n"},
+			command:      "ls",
+			fakeExitCode: 42,
+			wantExitCode: 42,
+			wantCallName: "ls",
+		},
+		{
+			name: "config override selects runner when multiple present",
+			files: map[string]string{
+				"package.json":  `{"scripts":{"start":"node"}}`,
+				"justfile":      "build:\n  go build\n",
+				".treepad.toml": "[exec]\nrunner = \"just\"\n",
+			},
+			command:      "build",
+			wantCallName: "just",
+			wantCallArgs: []string{"build"},
+		},
+		{
+			name:         "same worktree emits warning but still runs",
+			files:        map[string]string{"justfile": "build:\n  go build\n"},
+			command:      "build",
+			cwdSame:      true,
+			wantCallName: "just",
+			wantCallArgs: []string{"build"},
+			wantOutput:   []string{"warning"},
+		},
+		{
+			name:    "no command lists detected runner and scripts",
+			files:   map[string]string{"justfile": "build:\n  go build\ntest:\n  go test\n"},
+			command: "",
+			wantOutput: []string{"Runner: just", "build", "test"},
+		},
+		{
+			name:         "npm: double dash injected before extra args",
+			files:        map[string]string{"package.json": `{"scripts":{"test":"jest"}}`, "package-lock.json": "{}"},
+			command:      "test",
+			args:         []string{"--watch"},
+			wantCallName: "npm",
+			wantCallArgs: []string{"run", "test", "--", "--watch"},
+		},
+		{
+			name:         "npm: no double dash when no extra args",
+			files:        map[string]string{"package.json": `{"scripts":{"build":"tsc"}}`, "package-lock.json": "{}"},
+			command:      "build",
+			wantCallName: "npm",
+			wantCallArgs: []string{"run", "build"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
-			if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(tt.packageJSON), 0o644); err != nil {
-				t.Fatalf("write package.json: %v", err)
-			}
-			if err := os.WriteFile(filepath.Join(dir, "package-lock.json"), []byte("{}"), 0o644); err != nil {
-				t.Fatalf("write package-lock.json: %v", err)
+			for name, content := range tt.files {
+				if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+					t.Fatalf("write %s: %v", name, err)
+				}
 			}
 
+			cwd := "/some/other"
+			if tt.cwdSame {
+				cwd = dir
+			}
+
+			pt := &fakePassthroughRunner{exitCode: tt.fakeExitCode}
+			var out bytes.Buffer
 			porcelain := worktreePorcelainWithPath("feat", dir)
-			pt := &fakePassthroughRunner{}
-			svc := NewService(fakeRunner{output: porcelain}, &fakeSyncer{}, nil, &fakeHookRunner{}, &bytes.Buffer{}, strings.NewReader(""))
+			svc := NewService(fakeRunner{output: porcelain}, &fakeSyncer{}, nil, &fakeHookRunner{}, &out, strings.NewReader(""))
 
-			_, err := svc.Exec(context.Background(), ExecInput{
+			exitCode, err := svc.Exec(context.Background(), ExecInput{
 				Branch:  "feat",
 				Command: tt.command,
 				Args:    tt.args,
-				Cwd:     "/some/other",
+				Cwd:     cwd,
 				Runner:  pt,
 			})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if len(pt.calls) == 0 {
-				t.Fatal("expected a call")
+			if exitCode != tt.wantExitCode {
+				t.Errorf("exit code = %d, want %d", exitCode, tt.wantExitCode)
 			}
-			if !equalStringSlice(pt.calls[0].args, tt.wantArgs) {
-				t.Errorf("args = %v, want %v", pt.calls[0].args, tt.wantArgs)
+
+			if tt.wantCallName == "" {
+				if len(pt.calls) != 0 {
+					t.Errorf("expected no exec calls, got %d", len(pt.calls))
+				}
+			} else {
+				if len(pt.calls) == 0 {
+					t.Fatalf("expected an exec call, got none")
+				}
+				call := pt.calls[0]
+				if call.name != tt.wantCallName {
+					t.Errorf("call name = %q, want %q", call.name, tt.wantCallName)
+				}
+				if tt.wantCallArgs != nil && !equalStringSlice(call.args, tt.wantCallArgs) {
+					t.Errorf("call args = %v, want %v", call.args, tt.wantCallArgs)
+				}
+			}
+
+			outStr := out.String()
+			for _, want := range tt.wantOutput {
+				if !strings.Contains(outStr, want) {
+					t.Errorf("output missing %q: got %q", want, outStr)
+				}
 			}
 		})
-	}
-}
-
-func TestExec_zeroArgListsScripts(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "justfile"), []byte("build:\n  go build\ntest:\n  go test\n"), 0o644); err != nil {
-		t.Fatalf("write justfile: %v", err)
-	}
-
-	porcelain := worktreePorcelainWithPath("feat", dir)
-	pt := &fakePassthroughRunner{}
-	var out bytes.Buffer
-	svc := NewService(fakeRunner{output: porcelain}, &fakeSyncer{}, nil, &fakeHookRunner{}, &out, strings.NewReader(""))
-
-	exitCode, err := svc.Exec(context.Background(), ExecInput{
-		Branch: "feat",
-		Cwd:    "/some/other",
-		Runner: pt,
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if exitCode != 0 {
-		t.Errorf("ExitCode = %d, want 0", exitCode)
-	}
-	if len(pt.calls) != 0 {
-		t.Errorf("expected no exec calls, got %d", len(pt.calls))
-	}
-	outStr := out.String()
-	if !strings.Contains(outStr, "Runner: just") {
-		t.Errorf("output missing runner name: %q", outStr)
-	}
-	if !strings.Contains(outStr, "build") || !strings.Contains(outStr, "test") {
-		t.Errorf("output missing scripts: %q", outStr)
-	}
-}
-
-func TestExec_sameWorktreeWarns(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "justfile"), []byte("build:\n  go build\n"), 0o644); err != nil {
-		t.Fatalf("write justfile: %v", err)
-	}
-
-	porcelain := worktreePorcelainWithPath("feat", dir)
-	pt := &fakePassthroughRunner{}
-	var out bytes.Buffer
-	svc := NewService(fakeRunner{output: porcelain}, &fakeSyncer{}, nil, &fakeHookRunner{}, &out, strings.NewReader(""))
-
-	_, err := svc.Exec(context.Background(), ExecInput{
-		Branch:  "feat",
-		Command: "build",
-		Cwd:     dir, // same as worktree path
-		Runner:  pt,
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !strings.Contains(out.String(), "warning") {
-		t.Errorf("expected same-worktree warning, got: %q", out.String())
-	}
-}
-
-func TestExec_exitCodePropagated(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "justfile"), []byte("fail:\n  exit 1\n"), 0o644); err != nil {
-		t.Fatalf("write justfile: %v", err)
-	}
-
-	porcelain := worktreePorcelainWithPath("feat", dir)
-	pt := &fakePassthroughRunner{exitCode: 42}
-	svc := NewService(fakeRunner{output: porcelain}, &fakeSyncer{}, nil, &fakeHookRunner{}, &bytes.Buffer{}, strings.NewReader(""))
-
-	exitCode, err := svc.Exec(context.Background(), ExecInput{
-		Branch:  "feat",
-		Command: "ls", // raw exec, exitCode still comes from fake
-		Cwd:     "/some/other",
-		Runner:  pt,
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if exitCode != 42 {
-		t.Errorf("ExitCode = %d, want 42", exitCode)
-	}
-}
-
-func TestExec_configOverrideRunner(t *testing.T) {
-	dir := t.TempDir()
-	// Has package.json but .treepad.toml says runner=just
-	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"scripts":{"start":"node"}}`), 0o644); err != nil {
-		t.Fatalf("write package.json: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "justfile"), []byte("build:\n  go build\n"), 0o644); err != nil {
-		t.Fatalf("write justfile: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, ".treepad.toml"), []byte("[exec]\nrunner = \"just\"\n"), 0o644); err != nil {
-		t.Fatalf("write .treepad.toml: %v", err)
-	}
-
-	porcelain := worktreePorcelainWithPath("feat", dir)
-	pt := &fakePassthroughRunner{}
-	svc := NewService(fakeRunner{output: porcelain}, &fakeSyncer{}, nil, &fakeHookRunner{}, &bytes.Buffer{}, strings.NewReader(""))
-
-	_, err := svc.Exec(context.Background(), ExecInput{
-		Branch:  "feat",
-		Command: "build",
-		Cwd:     "/some/other",
-		Runner:  pt,
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(pt.calls) == 0 {
-		t.Fatal("expected a call")
-	}
-	if pt.calls[0].name != "just" {
-		t.Errorf("name = %q, want %q", pt.calls[0].name, "just")
 	}
 }
 

--- a/internal/treepad/service_exec_test.go
+++ b/internal/treepad/service_exec_test.go
@@ -1,0 +1,307 @@
+package treepad
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakePassthroughRunner records calls and returns a canned exit code.
+type fakePassthroughRunner struct {
+	calls    []ptCall
+	exitCode int
+	err      error
+}
+
+type ptCall struct {
+	dir  string
+	name string
+	args []string
+}
+
+func (f *fakePassthroughRunner) Run(_ context.Context, dir, name string, args ...string) (int, error) {
+	f.calls = append(f.calls, ptCall{dir: dir, name: name, args: args})
+	return f.exitCode, f.err
+}
+
+// worktreePorcelainWithPath builds porcelain output with a controllable path.
+func worktreePorcelainWithPath(branch, path string) []byte {
+	return []byte("worktree " + path + "\nHEAD abc123\nbranch refs/heads/" + branch + "\n\n")
+}
+
+func TestExec_unknownBranch(t *testing.T) {
+	svc := NewService(fakeRunner{output: twoWorktreePorcelain}, &fakeSyncer{}, nil, &fakeHookRunner{}, &bytes.Buffer{}, strings.NewReader(""))
+	_, err := svc.Exec(context.Background(), ExecInput{
+		Branch:  "nonexistent",
+		Command: "build",
+		Cwd:     "/some/other",
+		Runner:  &fakePassthroughRunner{},
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown branch")
+	}
+}
+
+func TestExec_scriptDispatch(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "justfile"), []byte("build:\n  go build ./...\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	porcelain := worktreePorcelainWithPath("feat", dir)
+	pt := &fakePassthroughRunner{}
+	var out bytes.Buffer
+	svc := NewService(fakeRunner{output: porcelain}, &fakeSyncer{}, nil, &fakeHookRunner{}, &out, strings.NewReader(""))
+
+	result, err := svc.Exec(context.Background(), ExecInput{
+		Branch:  "feat",
+		Command: "build",
+		Args:    []string{"--verbose"},
+		Cwd:     "/some/other",
+		Runner:  pt,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", result.ExitCode)
+	}
+	if len(pt.calls) != 1 {
+		t.Fatalf("want 1 call, got %d", len(pt.calls))
+	}
+	call := pt.calls[0]
+	if call.name != "just" {
+		t.Errorf("name = %q, want %q", call.name, "just")
+	}
+	wantArgs := []string{"build", "--verbose"}
+	if !equalStringSlice(call.args, wantArgs) {
+		t.Errorf("args = %v, want %v", call.args, wantArgs)
+	}
+	if call.dir != dir {
+		t.Errorf("dir = %q, want %q", call.dir, dir)
+	}
+}
+
+func TestExec_rawFallback(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "justfile"), []byte("build:\n  go build ./...\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	porcelain := worktreePorcelainWithPath("feat", dir)
+	pt := &fakePassthroughRunner{}
+	svc := NewService(fakeRunner{output: porcelain}, &fakeSyncer{}, nil, &fakeHookRunner{}, &bytes.Buffer{}, strings.NewReader(""))
+
+	_, err := svc.Exec(context.Background(), ExecInput{
+		Branch:  "feat",
+		Command: "ls",
+		Args:    []string{"-la"},
+		Cwd:     "/some/other",
+		Runner:  pt,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pt.calls) != 1 {
+		t.Fatalf("want 1 call, got %d", len(pt.calls))
+	}
+	call := pt.calls[0]
+	if call.name != "ls" {
+		t.Errorf("name = %q, want %q", call.name, "ls")
+	}
+	wantArgs := []string{"-la"}
+	if !equalStringSlice(call.args, wantArgs) {
+		t.Errorf("args = %v, want %v", call.args, wantArgs)
+	}
+}
+
+func TestExec_npmArgsDoubleDash(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"scripts":{"test":"jest"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "package-lock.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	porcelain := worktreePorcelainWithPath("feat", dir)
+	pt := &fakePassthroughRunner{}
+	svc := NewService(fakeRunner{output: porcelain}, &fakeSyncer{}, nil, &fakeHookRunner{}, &bytes.Buffer{}, strings.NewReader(""))
+
+	_, err := svc.Exec(context.Background(), ExecInput{
+		Branch:  "feat",
+		Command: "test",
+		Args:    []string{"--watch"},
+		Cwd:     "/some/other",
+		Runner:  pt,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	call := pt.calls[0]
+	wantArgs := []string{"run", "test", "--", "--watch"}
+	if !equalStringSlice(call.args, wantArgs) {
+		t.Errorf("args = %v, want %v", call.args, wantArgs)
+	}
+}
+
+func TestExec_npmNoDoubleDashWithoutArgs(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"scripts":{"build":"tsc"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "package-lock.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	porcelain := worktreePorcelainWithPath("feat", dir)
+	pt := &fakePassthroughRunner{}
+	svc := NewService(fakeRunner{output: porcelain}, &fakeSyncer{}, nil, &fakeHookRunner{}, &bytes.Buffer{}, strings.NewReader(""))
+
+	_, err := svc.Exec(context.Background(), ExecInput{
+		Branch:  "feat",
+		Command: "build",
+		Cwd:     "/some/other",
+		Runner:  pt,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	call := pt.calls[0]
+	wantArgs := []string{"run", "build"}
+	if !equalStringSlice(call.args, wantArgs) {
+		t.Errorf("args = %v, want %v", call.args, wantArgs)
+	}
+}
+
+func TestExec_zeroArgListsScripts(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "justfile"), []byte("build:\n  go build\ntest:\n  go test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	porcelain := worktreePorcelainWithPath("feat", dir)
+	pt := &fakePassthroughRunner{}
+	var out bytes.Buffer
+	svc := NewService(fakeRunner{output: porcelain}, &fakeSyncer{}, nil, &fakeHookRunner{}, &out, strings.NewReader(""))
+
+	result, err := svc.Exec(context.Background(), ExecInput{
+		Branch: "feat",
+		Cwd:    "/some/other",
+		Runner: pt,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", result.ExitCode)
+	}
+	if len(pt.calls) != 0 {
+		t.Errorf("expected no exec calls, got %d", len(pt.calls))
+	}
+	outStr := out.String()
+	if !strings.Contains(outStr, "Runner: just") {
+		t.Errorf("output missing runner name: %q", outStr)
+	}
+	if !strings.Contains(outStr, "build") || !strings.Contains(outStr, "test") {
+		t.Errorf("output missing scripts: %q", outStr)
+	}
+}
+
+func TestExec_sameWorktreeWarns(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "justfile"), []byte("build:\n  go build\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	porcelain := worktreePorcelainWithPath("feat", dir)
+	pt := &fakePassthroughRunner{}
+	var out bytes.Buffer
+	svc := NewService(fakeRunner{output: porcelain}, &fakeSyncer{}, nil, &fakeHookRunner{}, &out, strings.NewReader(""))
+
+	_, err := svc.Exec(context.Background(), ExecInput{
+		Branch:  "feat",
+		Command: "build",
+		Cwd:     dir, // same as worktree path
+		Runner:  pt,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), "warning") {
+		t.Errorf("expected same-worktree warning, got: %q", out.String())
+	}
+}
+
+func TestExec_exitCodePropagated(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "justfile"), []byte("fail:\n  exit 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	porcelain := worktreePorcelainWithPath("feat", dir)
+	pt := &fakePassthroughRunner{exitCode: 42}
+	svc := NewService(fakeRunner{output: porcelain}, &fakeSyncer{}, nil, &fakeHookRunner{}, &bytes.Buffer{}, strings.NewReader(""))
+
+	result, err := svc.Exec(context.Background(), ExecInput{
+		Branch:  "feat",
+		Command: "ls", // raw exec, exitCode still comes from fake
+		Cwd:     "/some/other",
+		Runner:  pt,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ExitCode != 42 {
+		t.Errorf("ExitCode = %d, want 42", result.ExitCode)
+	}
+}
+
+func TestExec_configOverrideRunner(t *testing.T) {
+	dir := t.TempDir()
+	// Has package.json but .treepad.toml says runner=just
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"scripts":{"start":"node"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "justfile"), []byte("build:\n  go build\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".treepad.toml"), []byte("[exec]\nrunner = \"just\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	porcelain := worktreePorcelainWithPath("feat", dir)
+	pt := &fakePassthroughRunner{}
+	svc := NewService(fakeRunner{output: porcelain}, &fakeSyncer{}, nil, &fakeHookRunner{}, &bytes.Buffer{}, strings.NewReader(""))
+
+	_, err := svc.Exec(context.Background(), ExecInput{
+		Branch:  "feat",
+		Command: "build",
+		Cwd:     "/some/other",
+		Runner:  pt,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pt.calls) == 0 {
+		t.Fatal("expected a call")
+	}
+	if pt.calls[0].name != "just" {
+		t.Errorf("name = %q, want %q", pt.calls[0].name, "just")
+	}
+}
+
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/treepad/service_exec_test.go
+++ b/internal/treepad/service_exec_test.go
@@ -34,7 +34,7 @@ func worktreePorcelainWithPath(branch, path string) []byte {
 }
 
 func TestExec_unknownBranch(t *testing.T) {
-	svc := NewService(fakeRunner{output: twoWorktreePorcelain}, &fakeSyncer{}, nil, &fakeHookRunner{}, &bytes.Buffer{}, strings.NewReader(""))
+	svc := NewService(fakeRunner{output: twoWorktreePorcelain}, &fakeSyncer{}, nil, &fakeHookRunner{}, &bytes.Buffer{}, strings.NewReader(""), nil)
 	_, err := svc.Exec(context.Background(), ExecInput{
 		Branch:  "nonexistent",
 		Command: "build",
@@ -143,7 +143,7 @@ func TestExec_dispatch(t *testing.T) {
 			pt := &fakePassthroughRunner{exitCode: tt.fakeExitCode}
 			var out bytes.Buffer
 			porcelain := worktreePorcelainWithPath("feat", dir)
-			svc := NewService(fakeRunner{output: porcelain}, &fakeSyncer{}, nil, &fakeHookRunner{}, &out, strings.NewReader(""))
+			svc := NewService(fakeRunner{output: porcelain}, &fakeSyncer{}, nil, &fakeHookRunner{}, &out, strings.NewReader(""), nil)
 
 			exitCode, err := svc.Exec(context.Background(), ExecInput{
 				Branch:  "feat",


### PR DESCRIPTION
## Summary

- Adds `tp exec <branch> [command] [args...]` to run commands in the root of any worktree with full stdio passthrough (TTY-aware)
- Detects the project task runner from marker files (`justfile`, `package.json`+lockfile, `pyproject.toml`, `Makefile`) and routes through it when the command matches a known script; falls back to raw exec otherwise
- `tp exec <branch>` with no command lists the detected runner and available scripts
- Adds `[exec] runner = "…"` to `.treepad.toml` for explicit override / disambiguation when multiple runners are present
- Exit codes propagate from the child process via `cli.Exit`

## Runners supported

| Runner | Detection | Scripts from |
|--------|-----------|--------------|
| `just` | `justfile` / `Justfile` | Parsed recipe names (skips `_`-prefixed private recipes) |
| `bun` / `pnpm` / `yarn` / `npm` | `package.json` + lockfile priority, then `packageManager` field | `package.json` `scripts` |
| `poetry` | `pyproject.toml` containing `[tool.poetry]` | `[tool.poetry.scripts]` |
| `uv` | `pyproject.toml` (no poetry marker) | `[project.scripts]` |
| `make` | `Makefile` | None (always raw exec) |

## Test plan

- [ ] `go test ./...` — 188 tests pass, no regressions
- [ ] `golangci-lint run ./...` — no issues
- [ ] Manual smoke: `tp exec <branch> <known-script>` routes via runner; `tp exec <branch> ls -la` raw execs; `tp exec <branch>` lists scripts; ambiguous runners produce a config hint; exit codes propagate

🤖 Generated with [Claude Code](https://claude.com/claude-code)