### PR TITLE
feat: add branch filtering to hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 ideas/
 dist
 /tp
+.treepad.toml

--- a/cmd/tp/testdata/script/hooks.txtar
+++ b/cmd/tp/testdata/script/hooks.txtar
@@ -1,7 +1,7 @@
 tp-init-repo
 
 # Write a config with post_new and post_remove hooks that append to an activity log.
-exec sh -c 'printf "[hooks]\npost_new = [\"mkdir -p .treepad && echo post_new:{{.Branch}} >> .treepad/activity.log\"]\npost_remove = [\"echo post_remove:{{.Branch}} >> .treepad/activity.log\"]\n" > .treepad.toml'
+exec sh -c 'printf "[[hooks.post_new]]\ncommand = \"mkdir -p .treepad && echo post_new:{{.Branch}} >> .treepad/activity.log\"\n\n[[hooks.post_remove]]\ncommand = \"echo post_remove:{{.Branch}} >> .treepad/activity.log\"\n" > .treepad.toml'
 
 exec tp new feature-x
 exists ../repo-feature-x
@@ -12,6 +12,6 @@ exec tp remove feature-x
 grep 'post_remove:feature-x' .treepad/activity.log
 
 # A failing pre_new hook should abort tp new before creating the worktree.
-exec sh -c 'printf "[hooks]\npre_new = [\"exit 1\"]\n" > .treepad.toml'
+exec sh -c 'printf "[[hooks.pre_new]]\ncommand = \"exit 1\"\n" > .treepad.toml'
 ! exec tp new should-not-exist
 ! exists ../repo-should-not-exist

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -38,22 +38,51 @@ Template rendering happens before the command is executed. A template error (e.g
 
 ## Configuration
 
-Hooks are declared under `[hooks]` in `.treepad.toml`. Each field is a list of shell command strings, executed sequentially via `sh -c`.
+Hooks are declared in `.treepad.toml` using TOML array-of-tables syntax. Each entry has a `command` field and optional `only`/`except` branch filters.
 
 ```toml
-[hooks]
-pre_new     = ["go mod download"]
-post_new    = [
-  "echo 'created {{.Branch}} at {{.WorktreePath}}' >> .treepad/activity.log",
-  "direnv allow {{.WorktreePath}}",
-]
-pre_remove  = ["git -C {{.WorktreePath}} diff --exit-code HEAD"]
-post_remove = []
-pre_sync    = []
-post_sync   = ["direnv allow {{.WorktreePath}}"]
+[[hooks.pre_new]]
+command = "go mod download"
+
+[[hooks.post_new]]
+command = "echo 'created {{.Branch}} at {{.WorktreePath}}' >> .treepad/activity.log"
+
+[[hooks.post_new]]
+command = "direnv allow {{.WorktreePath}}"
+
+[[hooks.pre_remove]]
+command = "git -C {{.WorktreePath}} diff --exit-code HEAD"
+
+[[hooks.post_sync]]
+command = "direnv allow {{.WorktreePath}}"
 ```
 
-Unset or empty lists are silently skipped. Unknown keys under `[hooks]` produce a parse error.
+Unset or absent hook lists are silently skipped.
+
+## Branch filtering
+
+Each hook entry supports `only` and `except` fields, which accept glob patterns (`*` matches within a path segment; `**` crosses path separators).
+
+```toml
+[[hooks.post_new]]
+command = "go mod download"
+only = ["feat/*", "fix/*"]   # only run for feat/ and fix/ branches
+
+[[hooks.post_new]]
+command = "echo 'hotfix started'"
+only = ["hotfix/**"]         # run for hotfix/ and any deeper nesting
+
+[[hooks.pre_remove]]
+command = "git -C {{.WorktreePath}} diff --exit-code HEAD"
+except = ["throwaway/*"]     # skip safety check on throwaway branches
+```
+
+Filter semantics:
+
+- If `only` is set, the branch must match at least one pattern — otherwise the entry is skipped.
+- If `except` is set, the branch must not match any pattern — otherwise the entry is skipped.
+- Both conditions apply when both are set (AND semantics): the branch must satisfy `only` and fail `except`.
+- An entry with neither field runs for all branches.
 
 > **Note:** Hooks are not supported on Windows in v1. `tp` returns an error if a hook is configured and executed on `GOOS=windows`.
 
@@ -71,12 +100,14 @@ Unset or empty lists are silently skipped. Unknown keys under `[hooks]` produce 
 Run dependency install and generate a seed task file when a new worktree is created. The agent opens to a ready environment.
 
 ```toml
-[hooks]
-post_new = [
-  "cd {{.WorktreePath}} && go mod download",
-  "cp .env.example {{.WorktreePath}}/.env",
-  "echo '# Task: {{.Branch}}\n\nSee CLAUDE.md for context.' > {{.WorktreePath}}/TASK.md",
-]
+[[hooks.post_new]]
+command = "cd {{.WorktreePath}} && go mod download"
+
+[[hooks.post_new]]
+command = "cp .env.example {{.WorktreePath}}/.env"
+
+[[hooks.post_new]]
+command = "echo '# Task: {{.Branch}}\n\nSee CLAUDE.md for context.' > {{.WorktreePath}}/TASK.md"
 ```
 
 ### Refuse removal of dirty worktrees
@@ -84,10 +115,8 @@ post_new = [
 Block `tp remove` if the worktree has uncommitted changes, preventing accidental data loss.
 
 ```toml
-[hooks]
-pre_remove = [
-  "git -C {{.WorktreePath}} diff --exit-code HEAD",
-]
+[[hooks.pre_remove]]
+command = "git -C {{.WorktreePath}} diff --exit-code HEAD"
 ```
 
 If the diff exits non-zero (dirty), `tp remove` aborts with a hook error before touching anything.
@@ -97,20 +126,22 @@ If the diff exits non-zero (dirty), `tp remove` aborts with a hook error before 
 Allow the new worktree's `.envrc` after sync so environment variables are live before the agent opens.
 
 ```toml
-[hooks]
-post_sync = ["direnv allow {{.WorktreePath}}"]
+[[hooks.post_sync]]
+command = "direnv allow {{.WorktreePath}}"
 ```
 
 Because `post_sync` fires per-worktree, every synced directory gets approved.
 
 ### Log agent activity to a shared file
 
-Append to a repo-level activity log on every worktree creation. Foreshadows the shared-state work (`.treepad/state.toml`) without coupling to it.
+Append to a repo-level activity log on every worktree creation.
 
 ```toml
-[hooks]
-post_new    = ["echo \"$(date -u +%FT%TZ) created {{.Branch}}\" >> .treepad/activity.log"]
-post_remove = ["echo \"$(date -u +%FT%TZ) removed {{.Branch}}\" >> .treepad/activity.log"]
+[[hooks.post_new]]
+command = "echo \"$(date -u +%FT%TZ) created {{.Branch}}\" >> .treepad/activity.log"
+
+[[hooks.post_remove]]
+command = "echo \"$(date -u +%FT%TZ) removed {{.Branch}}\" >> .treepad/activity.log"
 ```
 
 ### Run linters before sync overwrites
@@ -118,8 +149,22 @@ post_remove = ["echo \"$(date -u +%FT%TZ) removed {{.Branch}}\" >> .treepad/acti
 Guard against syncing a broken config into all worktrees.
 
 ```toml
-[hooks]
-pre_sync = ["./scripts/validate-vscode-settings.sh"]
+[[hooks.pre_sync]]
+command = "./scripts/validate-vscode-settings.sh"
+```
+
+### Run different setup per branch type
+
+Install dependencies only on feature branches; run integration tests only on fix branches.
+
+```toml
+[[hooks.post_new]]
+command = "cd {{.WorktreePath}} && go mod download"
+only = ["feat/**"]
+
+[[hooks.post_new]]
+command = "cd {{.WorktreePath}} && go test ./..."
+only = ["fix/**", "hotfix/**"]
 ```
 
 ## Limitations and roadmap

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require github.com/urfave/cli/v3 v3.8.0
 
 require github.com/BurntSushi/toml v1.6.0
 
+require github.com/bmatcuk/doublestar/v4 v4.10.0
+
 require (
 	github.com/rogpeppe/go-internal v1.14.1
 	golang.org/x/sys v0.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
+github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/hook/filter.go
+++ b/internal/hook/filter.go
@@ -1,0 +1,28 @@
+package hook
+
+import "github.com/bmatcuk/doublestar/v4"
+
+// shouldRun reports whether a hook entry should execute for the given branch.
+// If Only is set, the branch must match at least one pattern.
+// If Except is set, the branch must not match any pattern.
+// Both conditions apply when both are set (AND semantics).
+func shouldRun(entry HookEntry, branch string) bool {
+	if len(entry.Only) > 0 {
+		matched := false
+		for _, pattern := range entry.Only {
+			if ok, _ := doublestar.Match(pattern, branch); ok {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	for _, pattern := range entry.Except {
+		if ok, _ := doublestar.Match(pattern, branch); ok {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -24,19 +24,30 @@ type Data struct {
 	OutputDir    string // artifact output directory
 }
 
-// Runner executes a list of hook commands with the provided data.
-type Runner interface {
-	Run(ctx context.Context, hooks []string, data Data) error
+// HookEntry is a single hook command with optional branch filters.
+// Only and Except use glob patterns (** crosses path separators).
+// If Only is non-empty the branch must match at least one pattern.
+// If Except is non-empty the branch must not match any pattern.
+// Both conditions apply when both are set.
+type HookEntry struct {
+	Command string   `toml:"command"`
+	Only    []string `toml:"only"`
+	Except  []string `toml:"except"`
 }
 
-// Config holds the hook command lists for each event.
+// Runner executes a list of hook entries with the provided data.
+type Runner interface {
+	Run(ctx context.Context, hooks []HookEntry, data Data) error
+}
+
+// Config holds the hook entries for each event.
 type Config struct {
-	PreNew     []string `toml:"pre_new"`
-	PostNew    []string `toml:"post_new"`
-	PreRemove  []string `toml:"pre_remove"`
-	PostRemove []string `toml:"post_remove"`
-	PreSync    []string `toml:"pre_sync"`
-	PostSync   []string `toml:"post_sync"`
+	PreNew     []HookEntry `toml:"pre_new"`
+	PostNew    []HookEntry `toml:"post_new"`
+	PreRemove  []HookEntry `toml:"pre_remove"`
+	PostRemove []HookEntry `toml:"post_remove"`
+	PreSync    []HookEntry `toml:"pre_sync"`
+	PostSync   []HookEntry `toml:"post_sync"`
 }
 
 // IsZero reports whether no hooks are configured.
@@ -46,8 +57,8 @@ func (c Config) IsZero() bool {
 		len(c.PreSync) == 0 && len(c.PostSync) == 0
 }
 
-// For returns the hook commands for the given event.
-func (c Config) For(e Event) []string {
+// For returns the hook entries for the given event.
+func (c Config) For(e Event) []HookEntry {
 	switch e {
 	case PreNew:
 		return c.PreNew

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -32,7 +32,7 @@ func TestExecRunnerRun(t *testing.T) {
 		r := &fakeRunner{}
 		runner := hook.ExecRunner{Runner: r}
 
-		if err := runner.Run(context.Background(), []string{"echo {{.Branch}}"}, testData); err != nil {
+		if err := runner.Run(context.Background(), []hook.HookEntry{{Command: "echo {{.Branch}}"}}, testData); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if len(r.calls) != 1 {
@@ -60,7 +60,8 @@ func TestExecRunnerRun(t *testing.T) {
 		r := &fakeRunner{err: errors.New("exit status 1")}
 		runner := hook.ExecRunner{Runner: r}
 
-		if err := runner.Run(context.Background(), []string{"cmd1", "cmd2"}, testData); err == nil {
+		hooks := []hook.HookEntry{{Command: "cmd1"}, {Command: "cmd2"}}
+		if err := runner.Run(context.Background(), hooks, testData); err == nil {
 			t.Fatal("expected error, got nil")
 		}
 		if len(r.calls) != 1 {
@@ -72,7 +73,8 @@ func TestExecRunnerRun(t *testing.T) {
 		r := &fakeRunner{}
 		runner := hook.ExecRunner{Runner: r}
 
-		if err := runner.Run(context.Background(), []string{"cmd1", "cmd2"}, testData); err != nil {
+		hooks := []hook.HookEntry{{Command: "cmd1"}, {Command: "cmd2"}}
+		if err := runner.Run(context.Background(), hooks, testData); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if len(r.calls) != 2 {
@@ -84,7 +86,7 @@ func TestExecRunnerRun(t *testing.T) {
 		r := &fakeRunner{}
 		runner := hook.ExecRunner{Runner: r}
 
-		if err := runner.Run(context.Background(), []string{"echo {{.Invalid"}, testData); err == nil {
+		if err := runner.Run(context.Background(), []hook.HookEntry{{Command: "echo {{.Invalid"}}, testData); err == nil {
 			t.Fatal("expected error for bad template, got nil")
 		}
 		if len(r.calls) != 0 {
@@ -97,7 +99,7 @@ func TestExecRunnerRun(t *testing.T) {
 		runner := hook.ExecRunner{Runner: r}
 
 		cmd := "{{.Branch}} {{.WorktreePath}} {{.Slug}} {{.HookType}} {{.OutputDir}}"
-		if err := runner.Run(context.Background(), []string{cmd}, testData); err != nil {
+		if err := runner.Run(context.Background(), []hook.HookEntry{{Command: cmd}}, testData); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		want := "feat/foo /repo/feat-foo myrepo post_new /tmp/workspaces"
@@ -105,34 +107,101 @@ func TestExecRunnerRun(t *testing.T) {
 			t.Errorf("rendered = %q, want %q", got, want)
 		}
 	})
+
+	t.Run("skips entry when branch does not match only filter", func(t *testing.T) {
+		r := &fakeRunner{}
+		runner := hook.ExecRunner{Runner: r}
+
+		hooks := []hook.HookEntry{{Command: "cmd1", Only: []string{"fix/*"}}}
+		if err := runner.Run(context.Background(), hooks, testData); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(r.calls) != 0 {
+			t.Errorf("got %d calls, want 0 (branch feat/foo should not match fix/*)", len(r.calls))
+		}
+	})
+
+	t.Run("runs entry when branch matches only filter", func(t *testing.T) {
+		r := &fakeRunner{}
+		runner := hook.ExecRunner{Runner: r}
+
+		hooks := []hook.HookEntry{{Command: "cmd1", Only: []string{"feat/*"}}}
+		if err := runner.Run(context.Background(), hooks, testData); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(r.calls) != 1 {
+			t.Errorf("got %d calls, want 1", len(r.calls))
+		}
+	})
+
+	t.Run("skips entry when branch matches except filter", func(t *testing.T) {
+		r := &fakeRunner{}
+		runner := hook.ExecRunner{Runner: r}
+
+		hooks := []hook.HookEntry{{Command: "cmd1", Except: []string{"feat/*"}}}
+		if err := runner.Run(context.Background(), hooks, testData); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(r.calls) != 0 {
+			t.Errorf("got %d calls, want 0 (feat/foo matches except filter)", len(r.calls))
+		}
+	})
+
+	t.Run("only and except AND semantics: skips when only matches but except also matches", func(t *testing.T) {
+		r := &fakeRunner{}
+		runner := hook.ExecRunner{Runner: r}
+
+		hooks := []hook.HookEntry{{Command: "cmd1", Only: []string{"feat/**"}, Except: []string{"feat/foo"}}}
+		if err := runner.Run(context.Background(), hooks, testData); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(r.calls) != 0 {
+			t.Errorf("got %d calls, want 0 (feat/foo excluded by except)", len(r.calls))
+		}
+	})
+
+	t.Run("doublestar pattern matches nested branch", func(t *testing.T) {
+		r := &fakeRunner{}
+		runner := hook.ExecRunner{Runner: r}
+
+		deepData := hook.Data{Branch: "feat/JIRA-123/my-thing", HookType: "post_new"}
+		hooks := []hook.HookEntry{{Command: "cmd1", Only: []string{"feat/**"}}}
+		if err := runner.Run(context.Background(), hooks, deepData); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(r.calls) != 1 {
+			t.Errorf("got %d calls, want 1 (feat/** should match feat/JIRA-123/my-thing)", len(r.calls))
+		}
+	})
 }
 
 func TestConfigFor(t *testing.T) {
+	e := func(cmd string) hook.HookEntry { return hook.HookEntry{Command: cmd} }
 	cfg := hook.Config{
-		PreNew:     []string{"a"},
-		PostNew:    []string{"b", "c"},
-		PreRemove:  []string{"d"},
-		PostRemove: []string{"e"},
-		PreSync:    []string{"f"},
-		PostSync:   []string{"g"},
+		PreNew:     []hook.HookEntry{e("a")},
+		PostNew:    []hook.HookEntry{e("b"), e("c")},
+		PreRemove:  []hook.HookEntry{e("d")},
+		PostRemove: []hook.HookEntry{e("e")},
+		PreSync:    []hook.HookEntry{e("f")},
+		PostSync:   []hook.HookEntry{e("g")},
 	}
 
 	tests := []struct {
 		event hook.Event
-		want  []string
+		want  int
 	}{
-		{hook.PreNew, []string{"a"}},
-		{hook.PostNew, []string{"b", "c"}},
-		{hook.PreRemove, []string{"d"}},
-		{hook.PostRemove, []string{"e"}},
-		{hook.PreSync, []string{"f"}},
-		{hook.PostSync, []string{"g"}},
-		{"unknown", nil},
+		{hook.PreNew, 1},
+		{hook.PostNew, 2},
+		{hook.PreRemove, 1},
+		{hook.PostRemove, 1},
+		{hook.PreSync, 1},
+		{hook.PostSync, 1},
+		{"unknown", 0},
 	}
 	for _, tt := range tests {
 		got := cfg.For(tt.event)
-		if len(got) != len(tt.want) {
-			t.Errorf("For(%q): got %v, want %v", tt.event, got, tt.want)
+		if len(got) != tt.want {
+			t.Errorf("For(%q): got %d entries, want %d", tt.event, len(got), tt.want)
 		}
 	}
 }
@@ -141,7 +210,7 @@ func TestConfigIsZero(t *testing.T) {
 	if !(hook.Config{}).IsZero() {
 		t.Error("empty Config.IsZero() = false, want true")
 	}
-	if (hook.Config{PreNew: []string{"x"}}).IsZero() {
+	if (hook.Config{PreNew: []hook.HookEntry{{Command: "x"}}}).IsZero() {
 		t.Error("non-empty Config.IsZero() = true, want false")
 	}
 }

--- a/internal/hook/runner.go
+++ b/internal/hook/runner.go
@@ -18,15 +18,19 @@ type ExecRunner struct {
 	Runner CommandRunner
 }
 
-// Run executes each hook sequentially, stopping on the first error.
-func (e ExecRunner) Run(ctx context.Context, hooks []string, data Data) error {
+// Run executes each hook entry sequentially, skipping entries whose branch
+// filters do not match data.Branch, stopping on the first error.
+func (e ExecRunner) Run(ctx context.Context, hooks []HookEntry, data Data) error {
 	if runtime.GOOS == "windows" {
 		return fmt.Errorf("hooks are not supported on Windows")
 	}
-	for _, tmpl := range hooks {
-		rendered, err := renderCommand(tmpl, data)
+	for _, entry := range hooks {
+		if !shouldRun(entry, data.Branch) {
+			continue
+		}
+		rendered, err := renderCommand(entry.Command, data)
 		if err != nil {
-			return fmt.Errorf("render hook %q: %w", tmpl, err)
+			return fmt.Errorf("render hook %q: %w", entry.Command, err)
 		}
 		if _, err := e.Runner.Run(ctx, "sh", "-c", rendered); err != nil {
 			return fmt.Errorf("hook %q: %w", rendered, err)

--- a/internal/treepad/helpers.go
+++ b/internal/treepad/helpers.go
@@ -68,12 +68,12 @@ func hookData(slug, branch, wtPath, outputDir string) hook.Data {
 // configured for the event. Callers control the failure semantics: pre-hooks
 // should return the error to abort; post-hooks should log and continue.
 func runHook(ctx context.Context, d Deps, cfg hook.Config, event hook.Event, data hook.Data) error {
-	cmds := cfg.For(event)
-	if len(cmds) == 0 {
+	entries := cfg.For(event)
+	if len(entries) == 0 {
 		return nil
 	}
 	data.HookType = string(event)
-	return d.HookRunner.Run(ctx, cmds, data)
+	return d.HookRunner.Run(ctx, entries, data)
 }
 
 func artifactSpec(c config.ArtifactConfig) artifact.Spec {

--- a/internal/treepad/new_test.go
+++ b/internal/treepad/new_test.go
@@ -116,7 +116,7 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("fires PreNew and PostNew hooks", func(t *testing.T) {
-		toml := "[hooks]\npre_new = [\"marker-pre\"]\npost_new = [\"marker-post\"]\n"
+		toml := "[[hooks.pre_new]]\ncommand = \"marker-pre\"\n\n[[hooks.post_new]]\ncommand = \"marker-post\"\n"
 		if err := os.WriteFile(filepath.Join(mainPath, ".treepad.toml"), []byte(toml), 0o644); err != nil {
 			t.Fatalf("setup: %v", err)
 		}
@@ -148,7 +148,7 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("PreNew failure aborts before git worktree add", func(t *testing.T) {
-		toml := "[hooks]\npre_new = [\"fail\"]\n"
+		toml := "[[hooks.pre_new]]\ncommand = \"fail\"\n"
 		if err := os.WriteFile(filepath.Join(mainPath, ".treepad.toml"), []byte(toml), 0o644); err != nil {
 			t.Fatalf("setup: %v", err)
 		}
@@ -173,7 +173,7 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("PostNew failure logs warning but does not abort", func(t *testing.T) {
-		toml := "[hooks]\npost_new = [\"fail\"]\n"
+		toml := "[[hooks.post_new]]\ncommand = \"fail\"\n"
 		if err := os.WriteFile(filepath.Join(mainPath, ".treepad.toml"), []byte(toml), 0o644); err != nil {
 			t.Fatalf("setup: %v", err)
 		}

--- a/internal/treepad/remove_test.go
+++ b/internal/treepad/remove_test.go
@@ -63,7 +63,7 @@ func TestRemove(t *testing.T) {
 	})
 
 	t.Run("fires PreRemove and PostRemove hooks", func(t *testing.T) {
-		toml := "[hooks]\npre_remove = [\"marker-pre\"]\npost_remove = [\"marker-post\"]\n"
+		toml := "[[hooks.pre_remove]]\ncommand = \"marker-pre\"\n\n[[hooks.post_remove]]\ncommand = \"marker-post\"\n"
 		if err := os.WriteFile(filepath.Join(mainPath, ".treepad.toml"), []byte(toml), 0o644); err != nil {
 			t.Fatalf("setup: %v", err)
 		}
@@ -96,7 +96,7 @@ func TestRemove(t *testing.T) {
 	})
 
 	t.Run("PreRemove failure aborts before git worktree remove", func(t *testing.T) {
-		toml := "[hooks]\npre_remove = [\"fail\"]\n"
+		toml := "[[hooks.pre_remove]]\ncommand = \"fail\"\n"
 		if err := os.WriteFile(filepath.Join(mainPath, ".treepad.toml"), []byte(toml), 0o644); err != nil {
 			t.Fatalf("setup: %v", err)
 		}
@@ -121,7 +121,7 @@ func TestRemove(t *testing.T) {
 	})
 
 	t.Run("PostRemove failure logs warning but does not abort", func(t *testing.T) {
-		toml := "[hooks]\npost_remove = [\"fail\"]\n"
+		toml := "[[hooks.post_remove]]\ncommand = \"fail\"\n"
 		if err := os.WriteFile(filepath.Join(mainPath, ".treepad.toml"), []byte(toml), 0o644); err != nil {
 			t.Fatalf("setup: %v", err)
 		}

--- a/internal/treepad/testfakes_test.go
+++ b/internal/treepad/testfakes_test.go
@@ -106,7 +106,7 @@ func threeWorktreePorcelainWithMain(mainPath, feat1Path, feat2Path string) []byt
 }
 
 type fakeHookCall struct {
-	hooks []string
+	hooks []hook.HookEntry
 	data  hook.Data
 }
 
@@ -115,7 +115,7 @@ type fakeHookRunner struct {
 	err   error
 }
 
-func (f *fakeHookRunner) Run(_ context.Context, hooks []string, data hook.Data) error {
+func (f *fakeHookRunner) Run(_ context.Context, hooks []hook.HookEntry, data hook.Data) error {
 	f.calls = append(f.calls, fakeHookCall{hooks: hooks, data: data})
 	return f.err
 }


### PR DESCRIPTION
## Summary

Hook entries now use TOML array-of-tables syntax with optional `only` and `except` glob fields to filter by branch name. Entries are skipped when the branch doesn't match the filters, enabling per-branch-type hooks (e.g., run `go test` only on `fix/*` branches).

- `only`: allowlist patterns (branch must match at least one)
- `except`: blocklist patterns (branch must not match any)
- Both apply with AND semantics: branch must satisfy `only` AND fail `except`
- Glob patterns: `*` matches within path segments; `**` crosses them

## Breaking change
Old format no longer parses:
```toml
[hooks]
pre_new = ["cmd"]
```

Migrate to:
```toml
[[hooks.pre_new]]
command = "cmd"
only = ["feat/*"]    # optional
except = ["wip/*"]   # optional
```

## Test plan
- All 226 existing tests pass
- New tests added: filter matching, AND semantics, `**` nesting
- Updated txtar integration tests with new TOML format
- Docs updated with examples

🤖 Generated with Claude Code