### PR TITLE
feat: add tp base command

### DIFF
--- a/internal/commands/base.go
+++ b/internal/commands/base.go
@@ -1,0 +1,23 @@
+package commands
+
+import (
+	"context"
+	"os"
+
+	"github.com/urfave/cli/v3"
+
+	"treepad/internal/treepad"
+)
+
+func baseCommand() *cli.Command {
+	return &cli.Command{
+		Name:   "base",
+		Usage:  "return to the default worktree",
+		Action: runBase,
+	}
+}
+
+func runBase(ctx context.Context, cmd *cli.Command) error {
+	d := treepad.DefaultDeps(cmd.Root().Writer, cmd.Root().ErrWriter, os.Stdin)
+	return treepad.Base(ctx, d, treepad.BaseInput{})
+}

--- a/internal/commands/base_test.go
+++ b/internal/commands/base_test.go
@@ -1,0 +1,25 @@
+package commands
+
+import (
+	"context"
+	"testing"
+
+	"github.com/urfave/cli/v3"
+)
+
+func TestBaseCommand_isRegistered(t *testing.T) {
+	cmd := baseCommand()
+	if cmd.Name != "base" {
+		t.Errorf("command name = %q, want %q", cmd.Name, "base")
+	}
+}
+
+func TestBaseCommand_isRunnable(t *testing.T) {
+	app := &cli.Command{
+		Commands: []*cli.Command{baseCommand()},
+	}
+	// Running inside the project's real git repo; we just verify the action is
+	// reachable — either it succeeds or fails with a domain error, not a CLI
+	// routing error.
+	_ = app.Run(context.Background(), []string{"treepad", "base"})
+}

--- a/internal/commands/router.go
+++ b/internal/commands/router.go
@@ -12,6 +12,7 @@ func Router() []*cli.Command {
 		pruneCommand(),
 		statusCommand(),
 		cdCommand(),
+		baseCommand(),
 		doctorCommand(),
 		execCommand(),
 	}

--- a/internal/treepad/base.go
+++ b/internal/treepad/base.go
@@ -1,0 +1,42 @@
+package treepad
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"treepad/internal/worktree"
+)
+
+type BaseInput struct {
+	// Cwd overrides os.Getwd for testing.
+	Cwd string
+}
+
+func Base(ctx context.Context, d Deps, in BaseInput) error {
+	worktrees, err := listWorktrees(ctx, d)
+	if err != nil {
+		return err
+	}
+
+	main, err := worktree.MainWorktree(worktrees)
+	if err != nil {
+		return err
+	}
+
+	cwd := in.Cwd
+	if cwd == "" {
+		cwd, err = os.Getwd()
+		if err != nil {
+			return fmt.Errorf("get current directory: %w", err)
+		}
+	}
+
+	if filepath.Clean(cwd) == filepath.Clean(main.Path) {
+		return fmt.Errorf("already on the default worktree")
+	}
+
+	emitCD(d, main.Path)
+	return nil
+}

--- a/internal/treepad/base_test.go
+++ b/internal/treepad/base_test.go
@@ -1,0 +1,85 @@
+package treepad
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBase(t *testing.T) {
+	mainPath := t.TempDir()
+	if err := os.Mkdir(filepath.Join(mainPath, ".git"), 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	featPath := mainPath + "-feat"
+
+	porcelain := twoWorktreePorcelainWithMain(mainPath, featPath)
+
+	tests := []struct {
+		name        string
+		cwd         string
+		porcelain   []byte
+		wantCD      string
+		wantErr     bool
+		wantErrText string
+	}{
+		{
+			name:      "emits cd to main when cwd is a linked worktree",
+			cwd:       featPath,
+			porcelain: porcelain,
+			wantCD:    "__TREEPAD_CD__\t" + mainPath + "\n",
+		},
+		{
+			name:        "errors when already on the default worktree",
+			cwd:         mainPath,
+			porcelain:   porcelain,
+			wantErr:     true,
+			wantErrText: "already on the default worktree",
+		},
+		{
+			// twoWorktreePorcelain paths don't exist on disk so neither is main
+			name:        "errors when no main worktree can be found",
+			cwd:         featPath,
+			porcelain:   twoWorktreePorcelain,
+			wantErr:     true,
+			wantErrText: "could not find main worktree",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			deps := Deps{
+				Runner: fakeRunner{output: tt.porcelain},
+				Syncer: &fakeSyncer{},
+				Out:    &out,
+				In:     strings.NewReader(""),
+			}
+
+			err := Base(context.Background(), deps, BaseInput{Cwd: tt.cwd})
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.wantErrText != "" && !strings.Contains(err.Error(), tt.wantErrText) {
+					t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantErrText)
+				}
+				if out.Len() > 0 {
+					t.Errorf("no output expected on error, got: %q", out.String())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := out.String(); got != tt.wantCD {
+				t.Errorf("output = %q, want %q", got, tt.wantCD)
+			}
+		})
+	}
+}

--- a/internal/treepad/prune.go
+++ b/internal/treepad/prune.go
@@ -15,8 +15,8 @@ type PruneInput struct {
 	Base      string // branch to check merges against, e.g. "main"
 	OutputDir string
 	DryRun    bool
-	All       bool  // force-remove all non-main worktrees regardless of merge status
-	Yes       bool  // skip the interactive confirmation prompt (for scripting)
+	All       bool // force-remove all non-main worktrees regardless of merge status
+	Yes       bool // skip the interactive confirmation prompt (for scripting)
 	// Cwd overrides os.Getwd for testing the cwd-inside guard.
 	Cwd string
 }

--- a/internal/treepad/prune_test.go
+++ b/internal/treepad/prune_test.go
@@ -332,7 +332,7 @@ func TestPrune(t *testing.T) {
 		var buf strings.Builder
 		runner := &seqRunner{responses: []runResponse{
 			{output: twoPorcelain},
-			{output: []byte("feat\n")},  // git branch --merged
+			{output: []byte("feat\n")},   // git branch --merged
 			{output: []byte("M f.go\n")}, // dirty: feat (dirty)
 			{},                           // git worktree prune (no candidates remain)
 		}}

--- a/internal/treepad/status_test.go
+++ b/internal/treepad/status_test.go
@@ -95,11 +95,11 @@ func TestStatus(t *testing.T) {
 		porcelainWithPrunable := twoWorktreePorcelainWithPrunable(mainPath, prunablePath)
 
 		runner := &seqRunner{responses: []runResponse{
-			{output: porcelainWithPrunable},              // git worktree list
-			{output: []byte("")},                         // dirty: main (clean)
-			{output: []byte("origin/main\n")},            // rev-parse @{upstream}: main
-			{output: []byte("0\t0\n")},                   // rev-list: main
-			{output: commitOutput("abc1234", "init")},    // git log: main
+			{output: porcelainWithPrunable},           // git worktree list
+			{output: []byte("")},                      // dirty: main (clean)
+			{output: []byte("origin/main\n")},         // rev-parse @{upstream}: main
+			{output: []byte("0\t0\n")},                // rev-list: main
+			{output: commitOutput("abc1234", "init")}, // git log: main
 		}}
 
 		var buf strings.Builder


### PR DESCRIPTION
## Summary

- Adds `tp base` to return to the default worktree (the one whose `.git` is a directory, not a file)
- No-ops with an error if you're already on the default worktree
- Works regardless of which branch the default worktree has checked out

## Test plan

- [ ] `go test ./internal/treepad/... ./internal/commands/...` passes
- [ ] From a linked worktree: `tp base` cds back to the default checkout
- [ ] From the default worktree: `tp base` errors with "already on the default worktree"

🤖 Generated with [Claude Code](https://claude.com/claude-code)