### PR TITLE
feat: richer sync — gitignore-style patterns, directory support, better defaults

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -24,7 +24,7 @@ By default, uses the main worktree (the one with a `.git` directory) as the conf
 | `--use-current` | `-c` | Use current directory as config source instead of the main worktree |
 | `--sync-only` | | Sync configs only; skip artifact file generation |
 | `--output-dir` | `-o` | Directory for generated artifact files (default: `~/<repo-slug>-workspaces/`) |
-| `--include` | | Additional file patterns to sync (appended to `sync.files` in `.treepad.toml`) |
+| `--include` | | Additional file patterns to sync (appended to `sync.include` in `.treepad.toml`) |
 
 ### Examples
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,15 +24,18 @@ command = ["open", "{{.ArtifactPath}}"]
 
 File patterns to copy from the source worktree to all other worktrees.
 
-| Field   | Type     | Description                                     |
-| ------- | -------- | ----------------------------------------------- |
-| `files` | string[] | Glob patterns of files to sync across worktrees |
+| Field     | Type     | Description                                                                          |
+| --------- | -------- | ------------------------------------------------------------------------------------ |
+| `include` | string[] | Gitignore-style patterns of files/dirs to sync across worktrees                     |
 
-When `sync.files` is set, it **replaces** the defaults entirely. Use the `--include` flag to append additional patterns to whatever `sync.files` resolves to.
+Patterns use gitignore syntax: `**` matches across directories, a trailing `/` matches a directory and all its contents, and a `!` prefix negates (excludes) a pattern.
 
-**Default files** (used when no `[sync]` section or empty `files` array):
+When `sync.include` is set, it **replaces** the defaults entirely. Use the `--include` flag to append additional patterns to whatever `sync.include` resolves to.
 
-- `.claude/settings.local.json`
+**Default patterns** (used when no `[sync]` section or empty `include` array):
+
+- `.claude/` (entire directory)
+- `node_modules/` (entire directory)
 - `.env`
 - `.env.docker-compose`
 - `.vscode/settings.json`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,9 +24,9 @@ command = ["open", "{{.ArtifactPath}}"]
 
 File patterns to copy from the source worktree to all other worktrees.
 
-| Field     | Type     | Description                                                                          |
-| --------- | -------- | ------------------------------------------------------------------------------------ |
-| `include` | string[] | Gitignore-style patterns of files/dirs to sync across worktrees                     |
+| Field     | Type     | Description                                                     |
+| --------- | -------- | --------------------------------------------------------------- |
+| `include` | string[] | Gitignore-style patterns of files/dirs to sync across worktrees |
 
 Patterns use gitignore syntax: `**` matches across directories, a trailing `/` matches a directory and all its contents, and a `!` prefix negates (excludes) a pattern.
 
@@ -34,8 +34,8 @@ When `sync.include` is set, it **replaces** the defaults entirely. Use the `--in
 
 **Default patterns** (used when no `[sync]` section or empty `include` array):
 
-- `.claude/` (entire directory)
-- `node_modules/` (entire directory)
+- `.claude/`
+- `node_modules/`
 - `.env`
 - `.env.docker-compose`
 - `.vscode/settings.json`
@@ -75,14 +75,14 @@ Shell commands to run at lifecycle points in `tp` operations. See [hooks.md](hoo
 
 Each field is a list of shell command strings (Go `text/template` strings rendered before execution). An empty or absent list is a no-op.
 
-| Field | Type | Description |
-|---|---|---|
-| `pre_new` | string[] | Run before `git worktree add`; non-zero exit aborts the operation |
-| `post_new` | string[] | Run after artifact file is written; failure logs a warning |
-| `pre_remove` | string[] | Run before `git worktree remove`; non-zero exit aborts the operation |
-| `post_remove` | string[] | Run after `git branch -d`; failure logs a warning |
-| `pre_sync` | string[] | Run before each worktree's file sync; non-zero exit aborts that sync |
-| `post_sync` | string[] | Run after each worktree's file sync; failure logs a warning |
+| Field         | Type     | Description                                                          |
+| ------------- | -------- | -------------------------------------------------------------------- |
+| `pre_new`     | string[] | Run before `git worktree add`; non-zero exit aborts the operation    |
+| `post_new`    | string[] | Run after artifact file is written; failure logs a warning           |
+| `pre_remove`  | string[] | Run before `git worktree remove`; non-zero exit aborts the operation |
+| `post_remove` | string[] | Run after `git branch -d`; failure logs a warning                    |
+| `pre_sync`    | string[] | Run before each worktree's file sync; non-zero exit aborts that sync |
+| `post_sync`   | string[] | Run after each worktree's file sync; failure logs a warning          |
 
 ```toml
 [hooks]

--- a/internal/commands/sync.go
+++ b/internal/commands/sync.go
@@ -32,7 +32,7 @@ func syncCommand() *cli.Command {
 			},
 			&cli.StringSliceFlag{
 				Name:  "include",
-				Usage: "additional file patterns to sync (appended to sync.files in .treepad.toml)",
+				Usage: "additional file patterns to sync (appended to sync.include in .treepad.toml)",
 			},
 		},
 		Action: runSync,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,9 +34,10 @@ const defaultArtifactContentTemplate = `{
 }
 `
 
-func defaultSyncFiles() []string {
+func defaultSyncInclude() []string {
 	return []string{
-		".claude/settings.local.json",
+		".claude/",
+		"node_modules/",
 		".env",
 		".env.docker-compose",
 		".vscode/settings.json",
@@ -47,10 +48,12 @@ func defaultSyncFiles() []string {
 	}
 }
 
-// SyncConfig holds file patterns to copy across worktrees.
+// SyncConfig holds gitignore-style patterns controlling which files are copied across worktrees.
 type SyncConfig struct {
-	// Files replaces defaultSyncFiles entirely when non-empty.
-	Files []string `toml:"files"`
+	// Include replaces defaultSyncInclude entirely when non-empty.
+	// Patterns use gitignore syntax: ** crosses directories, trailing / matches
+	// a directory and all its contents, ! prefix negates a pattern.
+	Include []string `toml:"include"`
 }
 
 // ArtifactConfig describes the per-worktree file to generate.
@@ -141,9 +144,9 @@ func Load(repoRoot string) (Config, error) {
 		return cfg, fmt.Errorf("parsing %s: %w", configFileName, err)
 	}
 
-	// An explicit empty files array is treated as unset — defaults apply.
-	if len(fileCfg.Sync.Files) > 0 {
-		cfg.Sync.Files = fileCfg.Sync.Files
+	// An explicit empty include array is treated as unset — defaults apply.
+	if len(fileCfg.Sync.Include) > 0 {
+		cfg.Sync.Include = fileCfg.Sync.Include
 	}
 	if !fileCfg.Artifact.IsZero() {
 		cfg.Artifact = fileCfg.Artifact
@@ -158,13 +161,13 @@ func Load(repoRoot string) (Config, error) {
 		cfg.Exec = fileCfg.Exec
 	}
 
-	slog.Debug("loaded .treepad.toml", "dir", repoRoot, "syncFiles", cfg.Sync.Files)
+	slog.Debug("loaded .treepad.toml", "dir", repoRoot, "syncInclude", cfg.Sync.Include)
 	return cfg, nil
 }
 
 func defaults() Config {
 	return Config{
-		Sync: SyncConfig{Files: defaultSyncFiles()},
+		Sync: SyncConfig{Include: defaultSyncInclude()},
 		Artifact: ArtifactConfig{
 			FilenameTemplate: defaultArtifactFilenameTemplate,
 			ContentTemplate:  defaultArtifactContentTemplate,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -25,8 +25,8 @@ func TestLoad(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if !reflect.DeepEqual(cfg.Sync.Files, defaultSyncFiles()) {
-			t.Errorf("Sync.Files = %v, want defaults", cfg.Sync.Files)
+		if !reflect.DeepEqual(cfg.Sync.Include, defaultSyncInclude()) {
+			t.Errorf("Sync.Include = %v, want defaults", cfg.Sync.Include)
 		}
 		if cfg.Artifact.IsZero() {
 			t.Error("default Artifact should not be zero")
@@ -36,33 +36,33 @@ func TestLoad(t *testing.T) {
 		}
 	})
 
-	t.Run("valid config with custom sync files", func(t *testing.T) {
+	t.Run("valid config with custom sync include", func(t *testing.T) {
 		dir := t.TempDir()
 		writeFile(t, filepath.Join(dir, ".treepad.toml"), `
 [sync]
-files = ["custom.txt"]
+include = ["custom.txt"]
 `)
 		cfg, err := Load(dir)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if !reflect.DeepEqual(cfg.Sync.Files, []string{"custom.txt"}) {
-			t.Errorf("Sync.Files = %v, want [custom.txt]", cfg.Sync.Files)
+		if !reflect.DeepEqual(cfg.Sync.Include, []string{"custom.txt"}) {
+			t.Errorf("Sync.Include = %v, want [custom.txt]", cfg.Sync.Include)
 		}
 	})
 
-	t.Run("empty files array falls back to defaults", func(t *testing.T) {
+	t.Run("empty include array falls back to defaults", func(t *testing.T) {
 		dir := t.TempDir()
 		writeFile(t, filepath.Join(dir, ".treepad.toml"), `
 [sync]
-files = []
+include = []
 `)
 		cfg, err := Load(dir)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if !reflect.DeepEqual(cfg.Sync.Files, defaultSyncFiles()) {
-			t.Errorf("Sync.Files = %v, want defaults", cfg.Sync.Files)
+		if !reflect.DeepEqual(cfg.Sync.Include, defaultSyncInclude()) {
+			t.Errorf("Sync.Include = %v, want defaults", cfg.Sync.Include)
 		}
 	})
 
@@ -86,7 +86,7 @@ content = "{}"
 		dir := t.TempDir()
 		writeFile(t, filepath.Join(dir, ".treepad.toml"), `
 [sync]
-files = ["a.txt"]
+include = ["a.txt"]
 `)
 		cfg, err := Load(dir)
 		if err != nil {
@@ -99,7 +99,7 @@ files = ["a.txt"]
 
 	t.Run("legacy .treepad.json returns migration error", func(t *testing.T) {
 		dir := t.TempDir()
-		writeFile(t, filepath.Join(dir, ".treepad.json"), `{"sync":{"files":["a.txt"]}}`)
+		writeFile(t, filepath.Join(dir, ".treepad.json"), `{"sync":{"include":["a.txt"]}}`)
 
 		_, err := Load(dir)
 		if err == nil || !strings.Contains(err.Error(), ".treepad.json") {
@@ -130,14 +130,14 @@ files = ["a.txt"]
 	})
 }
 
-func TestDefaultSyncFiles(t *testing.T) {
-	files := defaultSyncFiles()
-	if len(files) != 8 {
-		t.Errorf("len(defaultSyncFiles()) = %d, want 8", len(files))
+func TestDefaultSyncInclude(t *testing.T) {
+	patterns := defaultSyncInclude()
+	if len(patterns) != 9 {
+		t.Errorf("len(defaultSyncInclude()) = %d, want 9", len(patterns))
 	}
-	for _, want := range []string{".env", ".vscode/settings.json"} {
-		if !slices.Contains(files, want) {
-			t.Errorf("defaultSyncFiles() missing %q", want)
+	for _, want := range []string{".claude/", "node_modules/", ".env", ".vscode/settings.json"} {
+		if !slices.Contains(patterns, want) {
+			t.Errorf("defaultSyncInclude() missing %q", want)
 		}
 	}
 }

--- a/internal/config/show.go
+++ b/internal/config/show.go
@@ -55,8 +55,8 @@ func Show(repoRoot string) (string, error) {
 }
 
 // loadFile reads and parses a single .treepad.toml file.
-// Returns (cfg, true, nil) if found with non-empty sync.files.
-// Returns (zero, false, nil) if missing or sync.files is empty.
+// Returns (cfg, true, nil) if found with non-empty sync.include.
+// Returns (zero, false, nil) if missing or sync.include is empty.
 // Returns (zero, false, err) if the file exists but cannot be read or parsed.
 func loadFile(path string) (Config, bool, error) {
 	data, err := os.ReadFile(path)
@@ -70,7 +70,7 @@ func loadFile(path string) (Config, bool, error) {
 	if _, err := toml.Decode(string(data), &cfg); err != nil {
 		return Config{}, false, fmt.Errorf("parsing %s: %w", path, err)
 	}
-	if len(cfg.Sync.Files) == 0 {
+	if len(cfg.Sync.Include) == 0 {
 		return Config{}, false, nil
 	}
 	return cfg, true, nil

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -1,12 +1,16 @@
-// Package sync copies files matching glob patterns between directories.
+// Package sync copies files matching gitignore-style patterns between directories.
 package sync
 
 import (
 	"fmt"
 	"io"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
 )
 
 // Config holds the source and target directories for a single sync operation.
@@ -16,7 +20,9 @@ type Config struct {
 }
 
 // Syncer copies files matching patterns from SourceDir to TargetDir.
-// Patterns are relative paths or globs anchored at SourceDir.
+// Patterns follow gitignore syntax: ** matches across directories,
+// trailing / matches a directory and all its contents,
+// and ! prefix negates a pattern.
 // Files absent in SourceDir are silently skipped.
 type Syncer interface {
 	Sync(patterns []string, cfg Config) error
@@ -25,24 +31,87 @@ type Syncer interface {
 type FileSyncer struct{}
 
 func (FileSyncer) Sync(patterns []string, cfg Config) error {
-	for _, pattern := range patterns {
-		matches, err := filepath.Glob(filepath.Join(cfg.SourceDir, pattern))
+	if err := validatePatterns(patterns); err != nil {
+		return err
+	}
+	include, exclude := parsePatterns(patterns)
+
+	return filepath.WalkDir(cfg.SourceDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return fmt.Errorf("invalid pattern %q: %w", pattern, err)
+			return err
 		}
-		slog.Debug("pattern matched", "pattern", pattern, "matches", len(matches))
-		for _, src := range matches {
-			rel, err := filepath.Rel(cfg.SourceDir, src)
-			if err != nil {
-				return fmt.Errorf("relative path for %s: %w", src, err)
-			}
-			dst := filepath.Join(cfg.TargetDir, rel)
-			if err := copyFile(src, dst); err != nil {
-				return fmt.Errorf("sync %s: %w", rel, err)
-			}
+		if d.IsDir() {
+			return nil
+		}
+
+		rel, err := filepath.Rel(cfg.SourceDir, path)
+		if err != nil {
+			return fmt.Errorf("relative path for %s: %w", path, err)
+		}
+
+		if !matchesInclude(filepath.ToSlash(rel), include, exclude) {
+			return nil
+		}
+
+		slog.Debug("syncing file", "rel", rel)
+		dst := filepath.Join(cfg.TargetDir, rel)
+		if err := copyFile(path, dst); err != nil {
+			return fmt.Errorf("sync %s: %w", rel, err)
+		}
+		return nil
+	})
+}
+
+func parsePatterns(patterns []string) (include, exclude []string) {
+	for _, p := range patterns {
+		if rest, ok := strings.CutPrefix(p, "!"); ok {
+			exclude = append(exclude, rest)
+		} else {
+			include = append(include, p)
+		}
+	}
+	return
+}
+
+// validatePatterns checks all patterns for invalid syntax before the walk begins.
+func validatePatterns(patterns []string) error {
+	for _, p := range patterns {
+		pat, _ := strings.CutPrefix(p, "!")
+		pat, _ = strings.CutSuffix(pat, "/")
+		if _, err := doublestar.Match(pat, ""); err != nil {
+			return fmt.Errorf("invalid pattern %q: %w", p, err)
 		}
 	}
 	return nil
+}
+
+// matchesInclude reports whether a forward-slash relative path should be synced.
+// A pattern with a trailing / matches the named directory and all descendants.
+// A ! prefix excludes an otherwise-matched path.
+func matchesInclude(rel string, include, exclude []string) bool {
+	for _, p := range include {
+		if matchPattern(p, rel) {
+			for _, ep := range exclude {
+				if matchPattern(ep, rel) {
+					return false
+				}
+			}
+			return true
+		}
+	}
+	return false
+}
+
+func matchPattern(pattern, rel string) bool {
+	if dir, ok := strings.CutSuffix(pattern, "/"); ok {
+		if ok, _ := doublestar.Match(dir, rel); ok {
+			return true
+		}
+		ok, _ := doublestar.Match(dir+"/**", rel)
+		return ok
+	}
+	ok, _ := doublestar.Match(pattern, rel)
+	return ok
 }
 
 func copyFile(src, dst string) error {

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -35,15 +35,14 @@ func TestFileSyncerSync(t *testing.T) {
 		wantErr  string
 	}{
 		{
-			name: "copies matching files",
+			name: "copies matching file",
 			setup: func(src string) {
 				writeFile(t, filepath.Join(src, ".env"), "SECRET=123")
 			},
 			patterns: []string{".env"},
 			check: func(t *testing.T, src, dst string) {
 				t.Helper()
-				got := readFile(t, filepath.Join(dst, ".env"))
-				if got != "SECRET=123" {
+				if got := readFile(t, filepath.Join(dst, ".env")); got != "SECRET=123" {
 					t.Errorf("content = %q, want %q", got, "SECRET=123")
 				}
 			},
@@ -62,6 +61,65 @@ func TestFileSyncerSync(t *testing.T) {
 				}
 				if readFile(t, filepath.Join(dst, ".vscode", "b.json")) != `{"b":2}` {
 					t.Error("b.json content mismatch")
+				}
+			},
+		},
+		{
+			name: "trailing slash pattern copies entire directory",
+			setup: func(src string) {
+				writeFile(t, filepath.Join(src, ".claude", "settings.local.json"), `{"key":"val"}`)
+				writeFile(t, filepath.Join(src, ".claude", "agents", "foo.md"), "# Foo")
+				writeFile(t, filepath.Join(src, "other.txt"), "ignore me")
+			},
+			patterns: []string{".claude/"},
+			check: func(t *testing.T, src, dst string) {
+				t.Helper()
+				if readFile(t, filepath.Join(dst, ".claude", "settings.local.json")) != `{"key":"val"}` {
+					t.Error("settings.local.json content mismatch")
+				}
+				if readFile(t, filepath.Join(dst, ".claude", "agents", "foo.md")) != "# Foo" {
+					t.Error("agents/foo.md content mismatch")
+				}
+				if _, err := os.Stat(filepath.Join(dst, "other.txt")); !os.IsNotExist(err) {
+					t.Error("other.txt should not be synced")
+				}
+			},
+		},
+		{
+			name: "double-star matches recursively",
+			setup: func(src string) {
+				writeFile(t, filepath.Join(src, "docs", "a.md"), "a")
+				writeFile(t, filepath.Join(src, "docs", "sub", "b.md"), "b")
+				writeFile(t, filepath.Join(src, "docs", "sub", "c.txt"), "c")
+			},
+			patterns: []string{"docs/**/*.md"},
+			check: func(t *testing.T, src, dst string) {
+				t.Helper()
+				if readFile(t, filepath.Join(dst, "docs", "a.md")) != "a" {
+					t.Error("a.md content mismatch")
+				}
+				if readFile(t, filepath.Join(dst, "docs", "sub", "b.md")) != "b" {
+					t.Error("sub/b.md content mismatch")
+				}
+				if _, err := os.Stat(filepath.Join(dst, "docs", "sub", "c.txt")); !os.IsNotExist(err) {
+					t.Error("c.txt should not be synced")
+				}
+			},
+		},
+		{
+			name: "negation pattern excludes file from matched directory",
+			setup: func(src string) {
+				writeFile(t, filepath.Join(src, ".claude", "settings.local.json"), "ok")
+				writeFile(t, filepath.Join(src, ".claude", "secret.md"), "secret")
+			},
+			patterns: []string{".claude/", "!.claude/secret.md"},
+			check: func(t *testing.T, src, dst string) {
+				t.Helper()
+				if readFile(t, filepath.Join(dst, ".claude", "settings.local.json")) != "ok" {
+					t.Error("settings.local.json should be synced")
+				}
+				if _, err := os.Stat(filepath.Join(dst, ".claude", "secret.md")); !os.IsNotExist(err) {
+					t.Error("secret.md should be excluded by ! pattern")
 				}
 			},
 		},
@@ -94,10 +152,10 @@ func TestFileSyncerSync(t *testing.T) {
 			},
 		},
 		{
-			name:     "invalid glob returns error",
-			setup:    func(src string) {},
+			name:    "invalid pattern returns error",
+			setup:   func(src string) {},
 			patterns: []string{"[invalid"},
-			wantErr:  "invalid pattern",
+			wantErr: "invalid pattern",
 		},
 	}
 

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -152,10 +152,10 @@ func TestFileSyncerSync(t *testing.T) {
 			},
 		},
 		{
-			name:    "invalid pattern returns error",
-			setup:   func(src string) {},
+			name:     "invalid pattern returns error",
+			setup:    func(src string) {},
 			patterns: []string{"[invalid"},
-			wantErr: "invalid pattern",
+			wantErr:  "invalid pattern",
 		},
 	}
 

--- a/internal/treepad/doctor_test.go
+++ b/internal/treepad/doctor_test.go
@@ -200,7 +200,7 @@ func TestDoctor(t *testing.T) {
 
 	t.Run("config-drift finding when worktree has different sync files", func(t *testing.T) {
 		// Write a .treepad.toml with different sync files to featPath.
-		toml := "[sync]\nfiles = [\"custom-file\"]\n"
+		toml := "[sync]\ninclude = [\"custom-file\"]\n"
 		if err := os.WriteFile(filepath.Join(featPath, ".treepad.toml"), []byte(toml), 0o644); err != nil {
 			t.Fatalf("setup: %v", err)
 		}

--- a/internal/treepad/helpers.go
+++ b/internal/treepad/helpers.go
@@ -29,7 +29,7 @@ func loadAndSync(ctx context.Context, d Deps, sourceDir string, extraPatterns []
 		return cfg, nil
 	}
 
-	patterns := slices.Concat(cfg.Sync.Files, extraPatterns)
+	patterns := slices.Concat(cfg.Sync.Include, extraPatterns)
 	slog.Debug("sync patterns", "patterns", patterns)
 
 	d.Log.Step("syncing configs to worktrees...")

--- a/internal/treepad/prune.go
+++ b/internal/treepad/prune.go
@@ -15,8 +15,8 @@ type PruneInput struct {
 	Base      string // branch to check merges against, e.g. "main"
 	OutputDir string
 	DryRun    bool
-	All       bool  // force-remove all non-main worktrees regardless of merge status
-	Yes       bool  // skip the interactive confirmation prompt (for scripting)
+	All       bool // force-remove all non-main worktrees regardless of merge status
+	Yes       bool // skip the interactive confirmation prompt (for scripting)
 	// Cwd overrides os.Getwd for testing the cwd-inside guard.
 	Cwd string
 }

--- a/internal/treepad/prune_test.go
+++ b/internal/treepad/prune_test.go
@@ -332,7 +332,7 @@ func TestPrune(t *testing.T) {
 		var buf strings.Builder
 		runner := &seqRunner{responses: []runResponse{
 			{output: twoPorcelain},
-			{output: []byte("feat\n")},  // git branch --merged
+			{output: []byte("feat\n")},   // git branch --merged
 			{output: []byte("M f.go\n")}, // dirty: feat (dirty)
 			{},                           // git worktree prune (no candidates remain)
 		}}

--- a/internal/treepad/status_test.go
+++ b/internal/treepad/status_test.go
@@ -95,11 +95,11 @@ func TestStatus(t *testing.T) {
 		porcelainWithPrunable := twoWorktreePorcelainWithPrunable(mainPath, prunablePath)
 
 		runner := &seqRunner{responses: []runResponse{
-			{output: porcelainWithPrunable},              // git worktree list
-			{output: []byte("")},                         // dirty: main (clean)
-			{output: []byte("origin/main\n")},            // rev-parse @{upstream}: main
-			{output: []byte("0\t0\n")},                   // rev-list: main
-			{output: commitOutput("abc1234", "init")},    // git log: main
+			{output: porcelainWithPrunable},           // git worktree list
+			{output: []byte("")},                      // dirty: main (clean)
+			{output: []byte("origin/main\n")},         // rev-parse @{upstream}: main
+			{output: []byte("0\t0\n")},                // rev-list: main
+			{output: commitOutput("abc1234", "init")}, // git log: main
 		}}
 
 		var buf strings.Builder


### PR DESCRIPTION
## Summary

- **Directory support**: `WalkDir` replaces `filepath.Glob`, so patterns can now match entire directory trees
- **Gitignore syntax**: `**` crosses path separators, trailing `/` includes a directory and all descendants, `!` prefix negates/excludes — powered by the existing `doublestar` dep (no new dependency)
- **Renamed config key**: `[sync] files` → `[sync] include` to align with the `--include` CLI flag (breaking change; no alias kept)
- **Updated defaults**: `.claude/` (whole folder) and `node_modules/` replace the single `.claude/settings.local.json` entry

## Test plan

- [ ] `go test ./...` passes (237 tests)
- [ ] Verify `.claude/` default copies nested files (e.g. `.claude/agents/`) to a target worktree
- [ ] Verify `!pattern` negation excludes a file that would otherwise be included
- [ ] Verify existing `.treepad.toml` using `[sync] files` gets a parse no-op (field ignored; defaults apply) — migration path is to rename the key

🤖 Generated with [Claude Code](https://claude.com/claude-code)