### PR TITLE
feat: zsh shell completion for tp commands

### DIFF
--- a/cmd/tp/main.go
+++ b/cmd/tp/main.go
@@ -24,11 +24,12 @@ func main() { os.Exit(Run(os.Args, os.Stdout, os.Stderr)) }
 // an exit code. main() is a thin wrapper so tests can invoke Run directly.
 func Run(args []string, stdout, stderr io.Writer) int {
 	cmd := &cli.Command{
-		Name:      "tp",
-		Usage:     "CLI for managing git worktrees",
-		Version:   version + " (commit: " + commit + ", built: " + date + ")",
-		Writer:    stdout,
-		ErrWriter: stderr,
+		Name:                  "tp",
+		Usage:                 "CLI for managing git worktrees",
+		Version:               version + " (commit: " + commit + ", built: " + date + ")",
+		EnableShellCompletion: true,
+		Writer:                stdout,
+		ErrWriter:             stderr,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:    "verbose",

--- a/cmd/tp/testdata/script/completion.txtar
+++ b/cmd/tp/testdata/script/completion.txtar
@@ -1,0 +1,3 @@
+tp-init-repo
+exec tp completion zsh
+stdout '#compdef tp'

--- a/internal/commands/cd.go
+++ b/internal/commands/cd.go
@@ -12,10 +12,11 @@ import (
 
 func cdCommand() *cli.Command {
 	return &cli.Command{
-		Name:      "cd",
-		Usage:     "cd into an existing worktree by branch name",
-		ArgsUsage: "<branch>",
-		Action:    runCD,
+		Name:          "cd",
+		Usage:         "cd into an existing worktree by branch name",
+		ArgsUsage:     "<branch>",
+		ShellComplete: completeWorktreeBranch,
+		Action:        runCD,
 	}
 }
 

--- a/internal/commands/completion.go
+++ b/internal/commands/completion.go
@@ -1,0 +1,44 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/urfave/cli/v3"
+
+	"treepad/internal/worktree"
+)
+
+// completeWorktreeBranch prints all non-detached worktree branches as completion candidates.
+func completeWorktreeBranch(ctx context.Context, cmd *cli.Command) {
+	printBranches(ctx, cmd, false)
+}
+
+// completeRemoveBranch prints non-main, non-detached branches — main cannot be removed.
+func completeRemoveBranch(ctx context.Context, cmd *cli.Command) {
+	printBranches(ctx, cmd, true)
+}
+
+// completeExecBranch completes the first positional arg (branch) of tp exec only.
+func completeExecBranch(ctx context.Context, cmd *cli.Command) {
+	if cmd.NArg() != 0 {
+		return
+	}
+	completeWorktreeBranch(ctx, cmd)
+}
+
+func printBranches(ctx context.Context, cmd *cli.Command, skipMain bool) {
+	wts, err := worktree.List(ctx, worktree.ExecRunner{})
+	if err != nil {
+		return
+	}
+	for _, wt := range wts {
+		if wt.Branch == "(detached)" {
+			continue
+		}
+		if skipMain && wt.IsMain {
+			continue
+		}
+		fmt.Fprintln(cmd.Root().Writer, wt.Branch)
+	}
+}

--- a/internal/commands/completion.go
+++ b/internal/commands/completion.go
@@ -3,23 +3,26 @@ package commands
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/urfave/cli/v3"
 
 	"treepad/internal/worktree"
 )
 
-// completeWorktreeBranch prints all non-detached worktree branches as completion candidates.
 func completeWorktreeBranch(ctx context.Context, cmd *cli.Command) {
-	printBranches(ctx, cmd, false)
+	writeBranches(ctx, worktree.ExecRunner{}, cmd.Root().Writer, func(wt worktree.Worktree) bool {
+		return wt.Branch != "(detached)"
+	})
 }
 
-// completeRemoveBranch prints non-main, non-detached branches — main cannot be removed.
+// completeRemoveBranch omits the main worktree, which tp remove refuses to remove.
 func completeRemoveBranch(ctx context.Context, cmd *cli.Command) {
-	printBranches(ctx, cmd, true)
+	writeBranches(ctx, worktree.ExecRunner{}, cmd.Root().Writer, func(wt worktree.Worktree) bool {
+		return !wt.IsMain && wt.Branch != "(detached)"
+	})
 }
 
-// completeExecBranch completes the first positional arg (branch) of tp exec only.
 func completeExecBranch(ctx context.Context, cmd *cli.Command) {
 	if cmd.NArg() != 0 {
 		return
@@ -27,18 +30,17 @@ func completeExecBranch(ctx context.Context, cmd *cli.Command) {
 	completeWorktreeBranch(ctx, cmd)
 }
 
-func printBranches(ctx context.Context, cmd *cli.Command, skipMain bool) {
-	wts, err := worktree.List(ctx, worktree.ExecRunner{})
+func writeBranches(ctx context.Context, runner worktree.CommandRunner, w io.Writer, include func(worktree.Worktree) bool) {
+	wts, err := worktree.List(ctx, runner)
 	if err != nil {
 		return
 	}
 	for _, wt := range wts {
-		if wt.Branch == "(detached)" {
+		if !include(wt) {
 			continue
 		}
-		if skipMain && wt.IsMain {
-			continue
+		if _, err := fmt.Fprintln(w, wt.Branch); err != nil {
+			return
 		}
-		fmt.Fprintln(cmd.Root().Writer, wt.Branch)
 	}
 }

--- a/internal/commands/completion_test.go
+++ b/internal/commands/completion_test.go
@@ -1,0 +1,88 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"treepad/internal/worktree"
+)
+
+type stubRunner struct {
+	out []byte
+	err error
+}
+
+func (s stubRunner) Run(_ context.Context, _ string, _ ...string) ([]byte, error) {
+	return s.out, s.err
+}
+
+func TestWriteBranches(t *testing.T) {
+	mainPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(mainPath, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	featPath := t.TempDir()
+
+	porcelain := fmt.Sprintf(
+		"worktree %s\nbranch refs/heads/main\n\nworktree %s\nbranch refs/heads/feat\n\n",
+		mainPath, featPath,
+	)
+	detachedPorcelain := fmt.Sprintf(
+		"worktree %s\ndetached\n\n",
+		featPath,
+	)
+
+	tests := []struct {
+		name      string
+		porcelain string
+		include   func(worktree.Worktree) bool
+		want      string
+	}{
+		{
+			name:      "all non-detached branches",
+			porcelain: porcelain,
+			include:   func(wt worktree.Worktree) bool { return wt.Branch != "(detached)" },
+			want:      "main\nfeat\n",
+		},
+		{
+			name:      "skip main worktree",
+			porcelain: porcelain,
+			include:   func(wt worktree.Worktree) bool { return !wt.IsMain && wt.Branch != "(detached)" },
+			want:      "feat\n",
+		},
+		{
+			name:      "detached worktree excluded by predicate",
+			porcelain: detachedPorcelain,
+			include:   func(wt worktree.Worktree) bool { return wt.Branch != "(detached)" },
+			want:      "",
+		},
+		{
+			name:      "runner error produces no output",
+			porcelain: "",
+			include:   func(worktree.Worktree) bool { return true },
+			want:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var runner worktree.CommandRunner
+			if tt.porcelain == "" {
+				runner = stubRunner{err: fmt.Errorf("git unavailable")}
+			} else {
+				runner = stubRunner{out: []byte(tt.porcelain)}
+			}
+
+			var buf bytes.Buffer
+			writeBranches(context.Background(), runner, &buf, tt.include)
+
+			if got := buf.String(); got != tt.want {
+				t.Errorf("got %q; want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/commands/exec.go
+++ b/internal/commands/exec.go
@@ -12,10 +12,11 @@ import (
 
 func execCommand() *cli.Command {
 	return &cli.Command{
-		Name:      "exec",
-		Usage:     "run a command in a specific worktree",
-		ArgsUsage: "<branch> [command] [args...]",
-		Action:    runExec,
+		Name:          "exec",
+		Usage:         "run a command in a specific worktree",
+		ArgsUsage:     "<branch> [command] [args...]",
+		ShellComplete: completeExecBranch,
+		Action:        runExec,
 	}
 }
 

--- a/internal/commands/remove.go
+++ b/internal/commands/remove.go
@@ -12,10 +12,11 @@ import (
 
 func removeCommand() *cli.Command {
 	return &cli.Command{
-		Name:      "remove",
-		Usage:     "remove a git worktree and its associated files",
-		ArgsUsage: "<branch>",
-		Action:    runRemove,
+		Name:          "remove",
+		Usage:         "remove a git worktree and its associated files",
+		ArgsUsage:     "<branch>",
+		ShellComplete: completeRemoveBranch,
+		Action:        runRemove,
 	}
 }
 


### PR DESCRIPTION
## Summary

- Enables urfave/cli v3 shell completion (`EnableShellCompletion: true`) — automatically adds a hidden `tp completion [bash|zsh|fish|pwsh]` subcommand
- Wires dynamic branch-name completion on `tp remove`, `tp cd`, and `tp exec` via `worktree.List()`; `remove` excludes the main worktree (which cannot be removed)

## Usage

Add to `.zshrc`:
\`\`\`zsh
eval "$(tp completion zsh)"
\`\`\`

`tp remove <TAB>`, `tp cd <TAB>`, and `tp exec <TAB>` then complete with real worktree branch names.

## Test plan

- [ ] `go test ./...`
- [ ] `go test -tags e2e ./cmd/tp/...` — 19 scripts pass including new `completion.txtar`
- [ ] Manual: `eval "$(./tp completion zsh)"` in a fresh zsh, tab-complete the three commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)