### PR TITLE
feat: tp ui — Enter exits with cd sentinel and graceful degrade (#71)

### DIFF
--- a/internal/treepad/ui.go
+++ b/internal/treepad/ui.go
@@ -31,15 +31,16 @@ type (
 )
 
 type uiModel struct {
-	ctx     context.Context
-	d       Deps
-	in      StatusInput
-	rows    []StatusRow
-	cursor  int
-	width   int
-	height  int
-	loading bool
-	err     error
+	ctx          context.Context
+	d            Deps
+	in           StatusInput
+	rows         []StatusRow
+	cursor       int
+	width        int
+	height       int
+	loading      bool
+	err          error
+	selectedPath string
 }
 
 func (m uiModel) Init() tea.Cmd {
@@ -81,6 +82,11 @@ func (m uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 		case "q", "ctrl+c":
 			return m, tea.Quit
+		case "enter":
+			if len(m.rows) > 0 {
+				m.selectedPath = m.rows[m.cursor].Path
+				return m, tea.Quit
+			}
 		case "up", "k":
 			if m.cursor > 0 {
 				m.cursor--
@@ -203,6 +209,20 @@ func UI(ctx context.Context, d Deps, in StatusInput) error {
 	}
 	m := uiModel{ctx: ctx, d: d, in: in, loading: true}
 	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithContext(ctx))
-	_, err := p.Run()
-	return err
+	final, err := p.Run()
+	if err != nil {
+		return err
+	}
+	// After alt-screen tears down, emit cd sentinel if Enter was pressed.
+	if fm, ok := final.(uiModel); ok && fm.selectedPath != "" {
+		uiEmitCD(d, fm.selectedPath)
+	}
+	return nil
+}
+
+// uiEmitCD writes the cd sentinel (consumed by the shell wrapper) and a
+// human-readable fallback line so users without the wrapper see where they'd land.
+func uiEmitCD(d Deps, path string) {
+	emitCD(d, path)
+	fmt.Fprintf(d.Out, "→ cd: %s\n", path)
 }

--- a/internal/treepad/ui_test.go
+++ b/internal/treepad/ui_test.go
@@ -171,4 +171,65 @@ func TestUIModel(t *testing.T) {
 			t.Errorf("view missing 'loading': %s", view)
 		}
 	})
+
+	t.Run("enter sets selectedPath and quits", func(t *testing.T) {
+		m := uiModel{
+			rows:   []StatusRow{{Branch: "main", Path: "/repo/main"}},
+			cursor: 0,
+		}
+		updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		m2 := updated.(uiModel)
+		if m2.selectedPath != "/repo/main" {
+			t.Errorf("selectedPath = %q, want %q", m2.selectedPath, "/repo/main")
+		}
+		if cmd == nil {
+			t.Fatal("expected quit command after enter")
+		}
+		msg := cmd()
+		if _, ok := msg.(tea.QuitMsg); !ok {
+			t.Errorf("got msg %T, want QuitMsg", msg)
+		}
+	})
+
+	t.Run("enter with no rows does not set selectedPath", func(t *testing.T) {
+		m := uiModel{}
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		m2 := updated.(uiModel)
+		if m2.selectedPath != "" {
+			t.Errorf("selectedPath = %q, want empty on no rows", m2.selectedPath)
+		}
+	})
+
+	t.Run("q quit does not set selectedPath", func(t *testing.T) {
+		m := uiModel{rows: rows2, cursor: 0}
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+		m2 := updated.(uiModel)
+		if m2.selectedPath != "" {
+			t.Errorf("q should not set selectedPath, got %q", m2.selectedPath)
+		}
+	})
+}
+
+func TestUIEmitCD(t *testing.T) {
+	t.Run("emits sentinel and human line", func(t *testing.T) {
+		var buf strings.Builder
+		deps := testDeps(&fakeRunner{}, &fakeSyncer{}, &fakeOpener{})
+		deps.Out = &buf
+
+		uiEmitCD(deps, "/some/path")
+
+		out := buf.String()
+		if !strings.Contains(out, "__TREEPAD_CD__\t/some/path") {
+			t.Errorf("missing sentinel in %q", out)
+		}
+		if !strings.Contains(out, "→ cd: /some/path") {
+			t.Errorf("missing human line in %q", out)
+		}
+		// Sentinel must come before human line
+		sentinelIdx := strings.Index(out, "__TREEPAD_CD__")
+		humanIdx := strings.Index(out, "→ cd:")
+		if sentinelIdx > humanIdx {
+			t.Error("sentinel must appear before human line")
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- `Enter` on a selected row sets `selectedPath` on the model and returns `tea.Quit`
- After `p.Run()` returns, `uiEmitCD()` emits the `__TREEPAD_CD__` sentinel then a human-readable line
- Graceful degrade: Enter on an empty row list is a no-op; cd path is only emitted if non-empty

## Test plan

- [ ] `go test ./...` passes
- [ ] `Enter` in `tp ui` exits and cd's into the selected worktree (requires shell integration)
- [ ] `Enter` on an empty list does nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)