### PR TITLE
fix(from-spec): avoid PROMPT.md worktree clutter; add Ctrl+C signal handling

### DIFF
--- a/cmd/tp/main.go
+++ b/cmd/tp/main.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/urfave/cli/v3"
 
@@ -48,7 +50,9 @@ func main() {
 		Commands: commands.Router(),
 	}
 
-	if err := cmd.Run(context.Background(), os.Args); err != nil {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	if err := cmd.Run(ctx, os.Args); err != nil {
 		ui.New(os.Stderr).Err(err.Error())
 		os.Exit(1)
 	}

--- a/internal/treepad/from_spec.go
+++ b/internal/treepad/from_spec.go
@@ -37,7 +37,7 @@ type promptData struct {
 }
 
 // FromSpec creates a worktree seeded from a spec (GitHub issue or local file),
-// renders a prompt into it, and hands off to a configured agent.
+// resolves a prompt (existing file or rendered template), and hands off to a configured agent.
 // Returns the agent's exit code (0 when no agent_command is configured).
 func FromSpec(ctx context.Context, d Deps, in FromSpecInput) (int, error) {
 	spec, err := resolveSpec(ctx, d, in.Issue, in.File)
@@ -50,7 +50,7 @@ func FromSpec(ctx context.Context, d Deps, in FromSpecInput) (int, error) {
 		return 0, err
 	}
 
-	promptPath, rendered, err := renderAndWritePrompt(d, res, in.Branch, spec)
+	promptPath, rendered, err := resolvePrompt(d, res, in.Branch, spec)
 	if err != nil {
 		return 0, err
 	}
@@ -75,18 +75,16 @@ func FromSpec(ctx context.Context, d Deps, in FromSpecInput) (int, error) {
 }
 
 // renderAndWritePrompt renders the configured prompt template and writes it into
-// the worktree. Returns the absolute path of the written file and the rendered body.
+// the worktree. Used by bulk mode where the written file is the deliverable.
 func renderAndWritePrompt(d Deps, res createWorktreeResult, branch, spec string) (path, rendered string, err error) {
 	if res.Cfg.FromSpec.PromptTemplate == "" {
 		return "", "", errors.New("from_spec.prompt_template not set in .treepad.toml; run `tp config init` to scaffold a default")
 	}
-
 	filename := res.Cfg.FromSpec.PromptFilename
 	if filename == "" {
 		filename = "PROMPT.md"
 	}
 	promptPath := filepath.Join(res.WorktreePath, filename)
-
 	data := promptData{
 		Spec:         spec,
 		Skills:       res.Cfg.FromSpec.Skills,
@@ -107,6 +105,52 @@ func renderAndWritePrompt(d Deps, res createWorktreeResult, branch, spec string)
 	}
 	d.Log.OK("wrote prompt to %s", promptPath)
 	return promptPath, body, nil
+}
+
+// resolvePrompt returns the prompt path and body to pass to the agent.
+// If a prompt file already exists in the worktree it is used as-is (not overwritten).
+// Otherwise the configured template is rendered and written to a temp file outside
+// the worktree so the working tree stays clean.
+func resolvePrompt(d Deps, res createWorktreeResult, branch, spec string) (path, rendered string, err error) {
+	filename := res.Cfg.FromSpec.PromptFilename
+	if filename == "" {
+		filename = "PROMPT.md"
+	}
+	worktreePromptPath := filepath.Join(res.WorktreePath, filename)
+
+	if existing, readErr := os.ReadFile(worktreePromptPath); readErr == nil {
+		d.Log.Info("using existing prompt at %s", worktreePromptPath)
+		return worktreePromptPath, string(existing), nil
+	}
+
+	if res.Cfg.FromSpec.PromptTemplate == "" {
+		return "", "", errors.New("from_spec.prompt_template not set in .treepad.toml; run `tp config init` to scaffold a default")
+	}
+
+	data := promptData{
+		Spec:         spec,
+		Skills:       res.Cfg.FromSpec.Skills,
+		Branch:       branch,
+		Slug:         res.RC.Slug,
+		WorktreePath: res.WorktreePath,
+		PromptPath:   worktreePromptPath,
+	}
+	body, err := renderPrompt(res.Cfg.FromSpec.PromptTemplate, data)
+	if err != nil {
+		return "", "", err
+	}
+
+	f, err := os.CreateTemp("", "treepad-prompt-*.md")
+	if err != nil {
+		return "", "", fmt.Errorf("create temp prompt: %w", err)
+	}
+	if _, werr := f.WriteString(body); werr != nil {
+		_ = f.Close()
+		return "", "", fmt.Errorf("write temp prompt: %w", werr)
+	}
+	_ = f.Close()
+	d.Log.Info("rendered prompt to %s", f.Name())
+	return f.Name(), body, nil
 }
 
 // resolveSpec returns the raw spec body from either a GitHub issue or a local file.

--- a/internal/treepad/from_spec_test.go
+++ b/internal/treepad/from_spec_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"treepad/internal/config"
 )
 
 func TestResolveSpec(t *testing.T) {
@@ -232,7 +234,7 @@ prompt_template = "branch={{.Branch}} spec={{.Spec}}"
 agent_command = []
 `
 
-	t.Run("file source creates worktree, writes PROMPT.md, and calls agent", func(t *testing.T) {
+	t.Run("file source creates worktree, renders prompt to temp, and calls agent", func(t *testing.T) {
 		specFile := filepath.Join(t.TempDir(), "spec.md")
 		if err := os.WriteFile(specFile, []byte(specBody), 0o644); err != nil {
 			t.Fatalf("setup: %v", err)
@@ -274,17 +276,60 @@ agent_command = ["echo", "{{.PromptPath}}"]
 			t.Errorf("agent name = %q, want echo", pt.calls[0].name)
 		}
 
-		// Verify PROMPT.md was written with rendered content.
-		promptPath := filepath.Join(pt.calls[0].dir, "PROMPT.md")
+		// Prompt must be in a temp file (not in the worktree).
+		if len(pt.calls[0].args) != 1 {
+			t.Fatalf("expected 1 arg to agent, got %d", len(pt.calls[0].args))
+		}
+		promptPath := pt.calls[0].args[0]
+		if strings.HasPrefix(promptPath, pt.calls[0].dir) {
+			t.Errorf("prompt file %q must not be inside the worktree %q", promptPath, pt.calls[0].dir)
+		}
 		content, err := os.ReadFile(promptPath)
 		if err != nil {
-			t.Fatalf("read PROMPT.md: %v", err)
+			t.Fatalf("read temp prompt: %v", err)
 		}
 		if !strings.Contains(string(content), specBody) {
-			t.Errorf("PROMPT.md does not contain spec body; got: %s", content)
+			t.Errorf("temp prompt does not contain spec body; got: %s", content)
 		}
 		if !strings.Contains(string(content), "feat/oauth") {
-			t.Errorf("PROMPT.md does not contain branch; got: %s", content)
+			t.Errorf("temp prompt does not contain branch; got: %s", content)
+		}
+
+		// Verify no PROMPT.md was written into the worktree.
+		if _, statErr := os.Stat(filepath.Join(pt.calls[0].dir, "PROMPT.md")); statErr == nil {
+			t.Error("PROMPT.md should not exist in the worktree")
+		}
+	})
+
+	t.Run("uses existing PROMPT.md from worktree without rendering template", func(t *testing.T) {
+		wt := t.TempDir()
+		existingContent := "my custom prompt"
+		promptFilePath := filepath.Join(wt, "PROMPT.md")
+		if err := os.WriteFile(promptFilePath, []byte(existingContent), 0o644); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+
+		res := createWorktreeResult{
+			WorktreePath: wt,
+			RC:           repoContext{Slug: "treepad"},
+			Cfg: config.Config{
+				FromSpec: config.FromSpecConfig{
+					PromptFilename: "PROMPT.md",
+					PromptTemplate: "should not be used: {{.Spec}}",
+				},
+			},
+		}
+		deps := testDeps(&seqRunner{}, &fakeSyncer{}, &fakeOpener{})
+
+		path, rendered, err := resolvePrompt(deps, res, "feat/test", specBody)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if path != promptFilePath {
+			t.Errorf("path = %q, want %q", path, promptFilePath)
+		}
+		if rendered != existingContent {
+			t.Errorf("rendered = %q, want existing file content %q", rendered, existingContent)
 		}
 	})
 


### PR DESCRIPTION
## Changes

- **`resolvePrompt`**: replaces `renderAndWritePrompt` for single `from-spec` runs. Uses an existing `PROMPT.md` in the worktree if present; otherwise renders the template to a temp file outside the worktree so `git status` stays clean. `renderAndWritePrompt` is kept for bulk mode where the written file is the deliverable.
- **`main.go`**: wraps context with `signal.NotifyContext` so Ctrl+C cancels the agent subprocess rather than blocking indefinitely in `cmd.Run`.
- **`.treepad.toml`**: updated `agent_command` to use `{{.Prompt}}` (rendered content) instead of `{{.PromptPath}}` (file path string).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)