### PR TITLE
fix(from-spec): launch interactive agents on the controlling terminal

### DIFF
--- a/e2e/tests/shell_init.txtar
+++ b/e2e/tests/shell_init.txtar
@@ -1,3 +1,3 @@
 exec tp shell-init
 stdout 'tp\(\)'
-stdout '__TREEPAD_CD__'
+stdout 'TREEPAD_CD_FD=3'

--- a/e2e/tests/shell_init_wrapper_v2.txtar
+++ b/e2e/tests/shell_init_wrapper_v2.txtar
@@ -1,0 +1,4 @@
+exec tp shell-init
+stdout 'TREEPAD_CD_FD=3'
+stdout '3>&1 1>&4'
+! stdout 'out=\$\(command tp'

--- a/internal/commands/shell_init.go
+++ b/internal/commands/shell_init.go
@@ -8,17 +8,16 @@ import (
 )
 
 // shellFunc is the shell wrapper function users source via `eval "$(tp shell-init)"`.
-// It captures all output from the real tp binary, extracts the __TREEPAD_CD__ directive
-// emitted by `tp new`, cd's into that path, then prints the remaining output.
+// Stdout (fd 1) passes straight to the terminal via fd 4, so tp's output streams
+// in real time and interactive children (e.g. claude) inherit a real TTY.
+// TREEPAD_CD_FD=3 tells tp to write the __TREEPAD_CD__ directive to fd 3, which
+// is redirected into the $(...) capture so only that payload is captured.
 const shellFunc = `tp() {
-  local out rc cd_path
-  out=$(command tp "$@")
-  rc=$?
-  cd_path=$(printf '%s\n' "$out" | awk -F'\t' '/^__TREEPAD_CD__\t/ {print $2; exit}')
-  printf '%s\n' "$out" | grep -v '^__TREEPAD_CD__	' || true
-  [ -n "$cd_path" ] && cd "$cd_path"
+  local cd_path rc
+  cd_path="$(TREEPAD_CD_FD=3 command tp "$@" 3>&1 1>&4)"; rc=$?
+  [ -n "$cd_path" ] && cd -- "$cd_path"
   return $rc
-}`
+} 4>&1`
 
 func shellInitCommand() *cli.Command {
 	return &cli.Command{

--- a/internal/commands/shell_init_test.go
+++ b/internal/commands/shell_init_test.go
@@ -24,9 +24,14 @@ func TestShellInitCommand(t *testing.T) {
 	}
 
 	out := buf.String()
-	for _, want := range []string{"tp()", "__TREEPAD_CD__"} {
+	for _, want := range []string{"tp()", "TREEPAD_CD_FD=3", "3>&1 1>&4"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("shell-init output missing %q; got:\n%s", want, out)
 		}
+	}
+	// Regression guard: stdout must not be captured by $(...) — that breaks
+	// interactive subprocesses and buffers all output until tp exits.
+	if strings.Contains(out, `out=$(command tp`) {
+		t.Errorf("shell-init output still uses old stdout-capturing pattern; got:\n%s", out)
 	}
 }

--- a/internal/treepad/deps.go
+++ b/internal/treepad/deps.go
@@ -30,6 +30,10 @@ type Deps struct {
 	IsTerminal func(w io.Writer) bool
 	// Sleep returns a channel that receives after d elapses (injectable for tests).
 	Sleep func(d time.Duration) <-chan time.Time
+	// CDSentinel, when non-nil, returns the writer emitCD uses for the
+	// __TREEPAD_CD__ payload instead of the fd-3 probe. Tests set this to a
+	// bytes.Buffer to avoid touching real file descriptors.
+	CDSentinel func() io.Writer
 }
 
 // DefaultDeps wires production implementations. It is the single composition

--- a/internal/treepad/exec.go
+++ b/internal/treepad/exec.go
@@ -11,6 +11,7 @@ import (
 
 	"treepad/internal/config"
 	tpexec "treepad/internal/exec"
+	"treepad/internal/tty"
 	"treepad/internal/worktree"
 )
 
@@ -21,14 +22,25 @@ type PassthroughRunner interface {
 	Run(ctx context.Context, dir, name string, args ...string) (int, error)
 }
 
+// openTTY is the function used to acquire a controlling terminal for
+// interactive subprocesses. Overridable in tests.
+var openTTY = tty.Open
+
 type osPassthroughRunner struct{}
 
 func (osPassthroughRunner) Run(ctx context.Context, dir, name string, args ...string) (int, error) {
 	cmd := osexec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	if tty := openTTY(); tty != nil {
+		defer tty.Close() //nolint:errcheck
+		cmd.Stdin = tty
+		cmd.Stdout = tty
+		cmd.Stderr = tty
+	} else {
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
 	if err := cmd.Run(); err != nil {
 		var exitErr *osexec.ExitError
 		if errors.As(err, &exitErr) {

--- a/internal/treepad/exec_test.go
+++ b/internal/treepad/exec_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -185,6 +186,44 @@ func TestExec_dispatch(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestOsPassthroughRunner_NoTTY_Fallback(t *testing.T) {
+	orig := openTTY
+	defer func() { openTTY = orig }()
+	openTTY = func() *os.File { return nil }
+
+	code, err := osPassthroughRunner{}.Run(context.Background(), t.TempDir(), "true")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+}
+
+func TestOsPassthroughRunner_TTY_ChildInherits(t *testing.T) {
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := openTTY
+	defer func() { openTTY = orig }()
+	openTTY = func() *os.File { return pw }
+
+	code, runErr := osPassthroughRunner{}.Run(context.Background(), t.TempDir(), "echo", "hello")
+	// pw is closed inside Run via defer tty.Close(); ReadAll gets EOF.
+	got, _ := io.ReadAll(pr)
+	_ = pr.Close()
+	if runErr != nil {
+		t.Fatalf("unexpected error: %v", runErr)
+	}
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+	if !strings.Contains(string(got), "hello") {
+		t.Errorf("expected child stdout on tty fd; got %q", got)
 	}
 }
 

--- a/internal/treepad/from_spec.go
+++ b/internal/treepad/from_spec.go
@@ -64,6 +64,7 @@ func FromSpec(ctx context.Context, d Deps, in FromSpecInput) (int, error) {
 		PromptPath:   promptPath,
 		Prompt:       rendered,
 	}
+	maybeWarnStaleWrapper(d, len(res.Cfg.FromSpec.AgentCommand) > 0)
 	code, err := runAgent(ctx, d, res.Cfg.FromSpec.AgentCommand, data)
 	if err != nil {
 		return code, err

--- a/internal/treepad/helpers.go
+++ b/internal/treepad/helpers.go
@@ -3,9 +3,12 @@ package treepad
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 
 	"treepad/internal/artifact"
 	"treepad/internal/config"
@@ -155,5 +158,49 @@ func templateData(repoSlug, branch, worktreePath, outputDir string) artifact.Tem
 }
 
 func emitCD(d Deps, path string) {
-	_, _ = fmt.Fprintf(d.Out, "__TREEPAD_CD__\t%s\n", path)
+	line := fmt.Sprintf("__TREEPAD_CD__\t%s\n", path)
+	if w := cdSentinelWriter(d); w != nil {
+		_, _ = io.WriteString(w, line)
+		return
+	}
+	_, _ = io.WriteString(d.Out, line)
+}
+
+// cdSentinelWriter returns a writer for the __TREEPAD_CD__ sentinel.
+// The new tp shell wrapper sets TREEPAD_CD_FD=3 and redirects fd 3 into
+// its $(...) capture, letting tp's stdout go to the real terminal. When the
+// env var is absent (stale wrapper, direct binary invocation, tests) it
+// returns nil so emitCD falls back to d.Out.
+func cdSentinelWriter(d Deps) io.Writer {
+	if d.CDSentinel != nil {
+		return d.CDSentinel()
+	}
+	fdStr := os.Getenv("TREEPAD_CD_FD")
+	if fdStr == "" {
+		return nil
+	}
+	fd, err := strconv.Atoi(fdStr)
+	if err != nil || fd < 0 {
+		return nil
+	}
+	return os.NewFile(uintptr(fd), "treepad-cd")
+}
+
+// maybeWarnStaleWrapper prints a one-line stderr hint when an agent_command is
+// configured but the new shell wrapper (which sets TREEPAD_CD_FD) has not been
+// installed. Fires only when TREEPAD_CD_FD is unset AND stdout is not a TTY
+// (i.e. inside the old wrapper's $(...) capture). No-op in all other contexts
+// (new wrapper active, CI, direct binary invocation).
+func maybeWarnStaleWrapper(d Deps, hasAgentCommand bool) {
+	if !hasAgentCommand {
+		return
+	}
+	if os.Getenv("TREEPAD_CD_FD") != "" {
+		return
+	}
+	if d.IsTerminal(d.Out) {
+		return
+	}
+	d.Log.Warn("stale shell wrapper detected — re-run: eval \"$(tp shell-init)\"")
+	d.Log.Warn("Your agent will still start interactively via /dev/tty.")
 }

--- a/internal/treepad/helpers_test.go
+++ b/internal/treepad/helpers_test.go
@@ -1,0 +1,43 @@
+package treepad
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"treepad/internal/ui"
+)
+
+func TestEmitCD_CDSentinelPath(t *testing.T) {
+	var sentinel, out bytes.Buffer
+	d := Deps{
+		Out:        &out,
+		Log:        ui.New(io.Discard),
+		CDSentinel: func() io.Writer { return &sentinel },
+		IsTerminal: func(io.Writer) bool { return false },
+	}
+	emitCD(d, "/some/path")
+
+	if !strings.Contains(sentinel.String(), "__TREEPAD_CD__\t/some/path") {
+		t.Errorf("sentinel missing payload; got %q", sentinel.String())
+	}
+	if out.Len() > 0 {
+		t.Errorf("expected nothing written to d.Out; got %q", out.String())
+	}
+}
+
+func TestEmitCD_FallbackToOut(t *testing.T) {
+	var out bytes.Buffer
+	d := Deps{
+		Out:        &out,
+		Log:        ui.New(io.Discard),
+		CDSentinel: nil, // fd-3 probe will fail in test process
+		IsTerminal: func(io.Writer) bool { return false },
+	}
+	emitCD(d, "/some/path")
+
+	if !strings.Contains(out.String(), "__TREEPAD_CD__\t/some/path") {
+		t.Errorf("d.Out missing payload; got %q", out.String())
+	}
+}

--- a/internal/tty/tty.go
+++ b/internal/tty/tty.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+// Package tty provides access to the process's controlling terminal.
+package tty
+
+import "os"
+
+// Open opens the controlling terminal of the current process for reading and
+// writing. Returns nil when no controlling terminal is available (CI, detached
+// session, no-TTY environments).
+func Open() *os.File {
+	f, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	if err != nil {
+		return nil
+	}
+	return f
+}

--- a/internal/tty/tty_windows.go
+++ b/internal/tty/tty_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+// Package tty provides access to the process's controlling terminal.
+package tty
+
+import "os"
+
+// Open returns nil on Windows; controlling terminal access is not supported.
+func Open() *os.File { return nil }


### PR DESCRIPTION
## Summary

- The `tp()` shell wrapper captured all stdout via `$()`, causing child processes (e.g. `claude`) to inherit a pipe instead of a TTY and run non-interactively
- `osPassthroughRunner` now opens `/dev/tty` for the agent subprocess so it gets the real controlling terminal regardless of wrapper version — fixes interactive mode immediately without requiring a wrapper reinstall
- Shell wrapper redesigned with fd-swapping (`TREEPAD_CD_FD=3 command tp "$@" 3>&1 1>&4`): tp's stdout streams directly to the terminal; only the `__TREEPAD_CD__` sentinel is captured on fd 3
- `maybeWarnStaleWrapper` detects the old wrapper and prints a hint to re-run `eval "$(tp shell-init)"`
- Controlling-terminal helpers extracted into `internal/tty`

## Test plan

- [ ] `just ci` passes
- [ ] `go install ./cmd/tp` then `tp from-spec --issue N <branch>` — claude opens interactively
- [ ] After `eval "$(tp shell-init)"`: worktree creation output streams in real time before handoff
- [ ] With old wrapper still active: stale wrapper warning appears on stderr; claude still interactive via `/dev/tty`
- [ ] In a no-TTY environment (`</dev/null`): falls back to inherited stdio, exits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)