### PR TITLE
fix(from-spec): strip sentinel tag on fd-3; open /dev/tty in blocking mode

### DIFF
--- a/internal/treepad/helpers.go
+++ b/internal/treepad/helpers.go
@@ -158,12 +158,11 @@ func templateData(repoSlug, branch, worktreePath, outputDir string) artifact.Tem
 }
 
 func emitCD(d Deps, path string) {
-	line := fmt.Sprintf("__TREEPAD_CD__\t%s\n", path)
 	if w := cdSentinelWriter(d); w != nil {
-		_, _ = io.WriteString(w, line)
+		_, _ = io.WriteString(w, path+"\n")
 		return
 	}
-	_, _ = io.WriteString(d.Out, line)
+	_, _ = fmt.Fprintf(d.Out, "__TREEPAD_CD__\t%s\n", path)
 }
 
 // cdSentinelWriter returns a writer for the __TREEPAD_CD__ sentinel.

--- a/internal/treepad/helpers_test.go
+++ b/internal/treepad/helpers_test.go
@@ -19,8 +19,8 @@ func TestEmitCD_CDSentinelPath(t *testing.T) {
 	}
 	emitCD(d, "/some/path")
 
-	if !strings.Contains(sentinel.String(), "__TREEPAD_CD__\t/some/path") {
-		t.Errorf("sentinel missing payload; got %q", sentinel.String())
+	if sentinel.String() != "/some/path\n" {
+		t.Errorf("sentinel = %q, want %q", sentinel.String(), "/some/path\n")
 	}
 	if out.Len() > 0 {
 		t.Errorf("expected nothing written to d.Out; got %q", out.String())

--- a/internal/tty/tty.go
+++ b/internal/tty/tty.go
@@ -3,15 +3,22 @@
 // Package tty provides access to the process's controlling terminal.
 package tty
 
-import "os"
+import (
+	"os"
+	"syscall"
+)
 
 // Open opens the controlling terminal of the current process for reading and
 // writing. Returns nil when no controlling terminal is available (CI, detached
 // session, no-TTY environments).
+//
+// syscall.Open + os.NewFile is used instead of os.OpenFile so that Go's
+// runtime poller does not flip O_NONBLOCK on the file description. Node/Bun
+// children reject a non-blocking TTY fd when setting up their stdio streams.
 func Open() *os.File {
-	f, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	fd, err := syscall.Open("/dev/tty", syscall.O_RDWR|syscall.O_CLOEXEC, 0)
 	if err != nil {
 		return nil
 	}
-	return f
+	return os.NewFile(uintptr(fd), "/dev/tty")
 }


### PR DESCRIPTION
## Summary

Two regressions in `tp from-spec` introduced by PR #89:

- **Error A** (`cd: no such file or directory: __TREEPAD_CD__\t/...`): `emitCD` wrote the legacy tagged line `__TREEPAD_CD__\t<path>\n` to fd 3, but the new wrapper captures fd 3 directly as `cd_path` without awk parsing. Fix: write only the bare path to a dedicated sentinel sink; keep the tagged format only for the `d.Out` fallback.

- **Error B** (`EINVAL: invalid argument, kqueue` / `process.stderr.fd undefined` in claude): `os.OpenFile("/dev/tty")` triggers Go's runtime poller, which calls `SetNonblock(true)` on the file description. The child (claude/Bun) inherits `O_NONBLOCK` on fd 0/1/2 and fails to construct TTY WriteStreams. Fix: open via `syscall.Open` + `os.NewFile` (bypasses the poller; fd stays blocking through the exec dup).

## Test plan

- [ ] All existing tests pass (`go test ./...` — 367 tests, 14 packages)
- [ ] `just ci` green (lint, build, unit, e2e)
- [ ] Manual: build locally → PATH shim → `eval "$(tp shell-init)"` → `tp from-spec --issue 85 feat/tp-repo-85` opens claude interactively with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)