### PR TITLE
feat(ui): add `d` key to diff selected worktree against origin/main

### DIFF
--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -93,7 +93,7 @@ Central location for all CLI command definitions. Separates CLI wiring from busi
 
 - `diffCommand()` — top-level diff command definition
   - Usage: `tp diff <branch> [-- <git-diff-args>...]`
-  - Flags: `--base` / `-b` (default: "main"), `--output` / `-o` (write to file)
+  - Flags: `--base` / `-b` (no hardcoded default; defers to config/fallback), `--output` / `-o` (write to file)
 - `runDiff(ctx, cmd)` — action handler for diffing worktrees
   - Parses branch argument (required) and extra args after `--`
   - Instantiates `treepad.Deps` via `DefaultDeps()`
@@ -106,19 +106,24 @@ Handles TOML configuration file loading, initialization, and display.
 
 ### `config.go`
 
-- `Config` struct — root config object with `Sync`, `Artifact`, `Open`, `Exec` fields
-- `SyncConfig` struct — contains `Files` (string array)
+- `Config` struct — root config object with `Sync`, `Artifact`, `Open`, `Exec`, `FromSpec`, `Diff` fields
+- `SyncConfig` struct — contains `Include` (string array of gitignore-style patterns)
 - `ArtifactConfig` struct — contains `FilenameTemplate` and `ContentTemplate` (text/template strings)
   - `IsZero()` — reports whether artifact is configured
 - `OpenConfig` struct — contains `Command` (string slice of template strings)
   - `IsZero()` — reports whether open command is configured
+- `DiffConfig` struct — contains `Base` (string; default `"origin/main"`)
+  - `IsZero()` — reports whether diff configuration is present
 - `ExecConfig` struct — contains `Runner` (string; valid values: just, npm, pnpm, yarn, bun, make, pip, poetry, uv)
   - `IsZero()` — reports whether exec runner is explicitly configured
+- `FromSpecConfig` struct — contains `PromptTemplate`, `PromptFilename`, `Skills`, `AgentCommand`
+  - `IsZero()` — reports whether from-spec configuration is present
 - `GlobalConfigPath()` — resolves global config path
   - Resolution order: `$TREEPAD_CONFIG` → `$XDG_CONFIG_HOME/treepad/config.toml` → `~/.config/treepad/config.toml`
 - `Load(repoRoot)` — loads `.treepad.toml` from repo, falls back to defaults
   - Returns clear error if legacy `.treepad.json` is found: "found .treepad.json; treepad now uses TOML..."
-- `defaultSyncFiles()` — built-in list of files to sync (VS Code, Claude, env)
+  - Merges file config with defaults: explicitly configured sections override defaults (IsZero check per section)
+- `defaultSyncInclude()` — built-in list of files to sync (VS Code, Claude, env)
 
 ### `init.go`
 
@@ -251,14 +256,19 @@ Pure business logic for worktree syncing and artifact file generation. Formerly 
 ### `diff.go`
 
 - `DiffInput` struct — parameterizes a tp diff invocation
-  - Fields: `Branch`, `Base` (default "main" if empty), `OutputFile` (optional), `ExtraArgs` (forwarded to git diff), `Runner` (PassthroughRunner override for testing)
+  - Fields: `Branch`, `Base` (empty defaults to config value via `resolveBase()`), `OutputFile` (optional), `ExtraArgs` (forwarded to git diff), `Runner` (PassthroughRunner override for testing)
 - `Diff(ctx, Deps, DiffInput)` — shows diff of target worktree against base using three-dot merge-base semantics
   - Lists worktrees and locates target by branch
   - Returns error if branch not found or worktree is prunable (with clear message and suggestion)
+  - Resolves base: if `DiffInput.Base` empty, calls `resolveBase(worktrees)` to load from config or use fallback
   - Uses three-dot semantics: `<base>...HEAD` (matches GitHub PR diff)
   - If OutputFile is set: runs `git -C <targetPath> diff --no-color <base>...HEAD [extra-args]`, captures output, writes uncolored patch to file, logs `[OK]`
   - If OutputFile is empty: executes `git diff <base>...HEAD [extra-args]` via PassthroughRunner with stdio inherited, respecting target worktree's git config (color, pager, delta, diff-so-fancy)
   - Exit code 0 on success; non-zero only on git command failure or file write error
+- `resolveBase(worktrees)` — helper function that resolves the base ref for diffing
+  - Finds the main worktree and loads its config via `config.Load()`
+  - Returns `config.Diff.Base` if configured
+  - Falls back to `"origin/main"` if config is not found or field is unset
 
 ### `opener.go`
 
@@ -356,7 +366,7 @@ tp [--verbose] <command>
 │       Routes through runner if command matches enumerated script
 │       Override with [exec] runner in .treepad.toml
 ├── diff [options] <branch> [-- <git-diff-args>...]
-│   ├── --base (-b, default: main)
+│   ├── --base (-b, default: from config or origin/main)
 │   └── --output (-o, optional)
 └── config
     ├── init [--global]
@@ -499,22 +509,24 @@ tp [--verbose] <command>
    - `Init()` dispatches `doRefresh()` and `doTick()` commands
    - `doRefresh()` calls `refreshStatus()` asynchronously; result arrives as `uiRefreshMsg`
    - Tick fires every 5s via `uiTickMsg`; skipped if an action is in flight
-   - Key events dispatch sync (`uiSyncDoneMsg`), remove (`uiRemoveDoneMsg`), prune (`uiPruneDoneMsg`), open (`uiOpenDoneMsg`) as async commands
+   - Key events dispatch sync (`uiSyncDoneMsg`), remove (`uiRemoveDoneMsg`), prune (`uiPruneDoneMsg`), open (`uiOpenDoneMsg`), diff (`uiDiffDoneMsg`) as async commands
+   - `d` key (if not prunable) calls `doDiff()` to suspend alt-screen, run `git diff <base>...HEAD`, and return to TUI on exit
    - `y` key stores path in `yankPath`; `View()` emits OSC-52 escape sequence; `uiYankClearMsg` clears it next tick
    - `Enter` sets `selectedPath` and returns `tea.Quit`
 7. After `p.Run()` returns, if `selectedPath` is non-empty:
    - Emits `__TREEPAD_CD__\t<path>` sentinel to stdout (shell wrapper cd's)
    - Emits human-readable `→ cd: <path>` line
 
-## Data Flow Example: `tp diff <branch> [--base main] [-o file] [-- <git-diff-args>...]`
+## Data Flow Example: `tp diff <branch> [--base ref] [-o file] [-- <git-diff-args>...]`
 
 1. `cmd/tp/main.go` parses flags and calls `commands.Router()`
-2. `commands.diffCommand()` defines CLI interface with branch positional arg, `--base` / `-b` flag (default "main"), `--output` / `-o` flag, and `--` arg forwarding
+2. `commands.diffCommand()` defines CLI interface with branch positional arg, `--base` / `-b` flag (no hardcoded default), `--output` / `-o` flag, and `--` arg forwarding
 3. `runDiff()` parses branch arg, base and output flags, and extra args after `--`; instantiates `treepad.Deps` via `DefaultDeps()`, calls `Diff()`
 4. `Diff()` executes:
    - Lists all worktrees via `worktree.List()` and finds target by branch
    - Returns error if branch not found (with suggestion to sync)
    - Checks if worktree is prunable; returns clear error with suggestion to prune if so
+   - Resolves base: if `DiffInput.Base` is empty, calls `resolveBase(worktrees)` to load from config or use fallback `"origin/main"`
    - Builds three-dot ref string: `<base>...HEAD`
    - **If output file specified:** runs `git -C <targetPath> diff --no-color <base>...HEAD [extra-args]` via `d.Runner.Run()` (uncolored capture), writes raw patch bytes to file, logs `[OK]` to stderr, returns
    - **If no output file:** executes `git diff <base>...HEAD [extra-args]` via PassthroughRunner with stdio inherited from caller, respecting target worktree's git config (pager, color, delta, diff-so-fancy), returns exit code or error
@@ -522,4 +534,4 @@ tp [--verbose] <command>
 
 ---
 
-**Last Updated:** April 19, 2026 (replaced `tp status --watch` with `tp ui` BubbleTea TUI fleet commander; added `internal/treepad/ui.go` and `internal/commands/ui.go`; extracted `refreshStatus()` seam in `status.go`; added `ErrNotTTY` sentinel; added OSC-52 yank, Enter→cd, inline sync/remove/prune actions, help overlay)
+**Last Updated:** April 22, 2026 (added `DiffConfig` struct to config with `Base` field (default `origin/main`); added `resolveBase()` helper in `diff.go` to resolve base from config; removed hardcoded default from `--base` flag in `tp diff` (now defers to config/fallback); added `d` key binding in TUI with `doDiff()` method and `uiDiffDoneMsg` for inline diffing in fleet view; updated help overlay and documentation)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -555,6 +555,7 @@ Renders a full-screen alt-screen display that auto-refreshes every 5 seconds. Sh
 | `s` | Sync selected worktree configs |
 | `S` | Sync all worktrees (fleet sync) |
 | `o` | Open artifact file for selected worktree |
+| `d` | Diff selected worktree against base (default from config or `origin/main`) |
 | `y` | Yank (copy) path to clipboard via OSC-52 |
 | `r` | Remove selected worktree (prompts for confirmation) |
 | `p` | Prune merged worktrees (prompts for confirmation) |
@@ -576,13 +577,13 @@ Show the diff of a worktree against a base branch using three-dot merge-base sem
 tp diff [options] <branch> [-- <git-diff-args>...]
 ```
 
-Displays the diff between the target worktree's branch and a base ref (default: `main`) using `git diff <base>...HEAD` semantics, which matches the diff view in GitHub pull requests. The diff is shown in the terminal with color and paging inherited from the target worktree's git configuration (respects `delta`, `diff-so-fancy`, or other configured tools). Optionally writes a plain (uncolored) patch to a file with `--output`.
+Displays the diff between the target worktree's branch and a base ref (default: `origin/main`, or the value of `[diff] base` in `.treepad.toml`) using `git diff <base>...HEAD` semantics, which matches the diff view in GitHub pull requests. The diff is shown in the terminal with color and paging inherited from the target worktree's git configuration (respects `delta`, `diff-so-fancy`, or other configured tools). Optionally writes a plain (uncolored) patch to a file with `--output`.
 
 ### Flags
 
 | Flag | Short | Description |
 |------|-------|-------------|
-| `--base` | `-b` | Ref to diff against (default: `main`) |
+| `--base` | `-b` | Ref to diff against (default: from config `[diff] base` or `origin/main`; not set via CLI flag unless explicitly provided) |
 | `--output` | `-o` | Write uncolored patch to `file` instead of terminal; outputs `[OK]` to stderr on success |
 
 ### Argument Forwarding

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -105,6 +105,33 @@ Command to run when `tp new --open` is used. Each element is a Go text/template 
 command = ["open", "{{.ArtifactPath}}"]
 ```
 
+### `[diff]` section
+
+Configuration for the `tp diff` command and the `d` key in `tp ui`. Controls the base ref used for diffing.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `base` | string | Git ref to diff against (default: `origin/main`); used by `tp diff` when `--base` is not specified, and by the TUI `d` key binding |
+
+**Default** (when no `[diff]` section is present):
+
+```toml
+[diff]
+base = "origin/main"
+```
+
+**Examples:**
+
+```toml
+[diff]
+base = "main"
+```
+
+```toml
+[diff]
+base = "develop"
+```
+
 ### `[from_spec]` section
 
 Configuration for the `tp from-spec` command, which creates worktrees from specifications (GitHub issues or markdown files) and hands off to agents.

--- a/e2e/tests/diff.txtar
+++ b/e2e/tests/diff.txtar
@@ -1,4 +1,10 @@
 tp-init-repo
+
+# Seed an origin remote so the default base (origin/main) resolves.
+exec git init --bare ../origin.git
+exec git remote add origin ../origin.git
+exec git push -u origin main
+
 tp-add-worktree feat
 
 # Seed a commit on the feat branch so there is something to diff.

--- a/internal/commands/diff.go
+++ b/internal/commands/diff.go
@@ -16,7 +16,7 @@ func diffCommand() *cli.Command {
 		Usage:     "diff a worktree against a base branch",
 		ArgsUsage: "<branch> [-- <git-diff-args>...]",
 		Flags: []cli.Flag{
-			&cli.StringFlag{Name: "base", Aliases: []string{"b"}, Value: "main", Usage: "base branch to diff against"},
+			&cli.StringFlag{Name: "base", Aliases: []string{"b"}, Usage: "base branch to diff against (default: origin/main, or [diff] base in .treepad.toml)"},
 			&cli.StringFlag{Name: "output", Aliases: []string{"o"}, Usage: "write diff to `file` instead of terminal"},
 		},
 		Action: runDiff,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,6 +80,16 @@ func (o OpenConfig) IsZero() bool {
 	return len(o.Command) == 0
 }
 
+// DiffConfig controls the base ref used by `tp diff` and the `d` TUI binding.
+type DiffConfig struct {
+	Base string `toml:"base"` // default "origin/main"
+}
+
+// IsZero reports whether no diff configuration is present.
+func (d DiffConfig) IsZero() bool {
+	return d.Base == ""
+}
+
 // ExecConfig controls the task runner used by `tp exec`.
 type ExecConfig struct {
 	// Runner overrides auto-detection. Valid values: just, npm, pnpm, yarn, bun,
@@ -121,6 +131,7 @@ type Config struct {
 	Hooks    hook.Config    `toml:"hooks"`
 	Exec     ExecConfig     `toml:"exec"`
 	FromSpec FromSpecConfig `toml:"from_spec"`
+	Diff     DiffConfig     `toml:"diff"`
 }
 
 // GlobalConfigPath returns the path to the global config file.
@@ -185,6 +196,9 @@ func Load(repoRoot string) (Config, error) {
 	if !fileCfg.FromSpec.IsZero() {
 		cfg.FromSpec = fileCfg.FromSpec
 	}
+	if !fileCfg.Diff.IsZero() {
+		cfg.Diff = fileCfg.Diff
+	}
 
 	slog.Debug("loaded .treepad.toml", "dir", repoRoot, "syncInclude", cfg.Sync.Include)
 	return cfg, nil
@@ -198,5 +212,6 @@ func defaults() Config {
 			ContentTemplate:  defaultArtifactContentTemplate,
 		},
 		Open: OpenConfig{Command: []string{"open", "{{.ArtifactPath}}"}},
+		Diff: DiffConfig{Base: "origin/main"},
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -165,6 +165,40 @@ prompt_template = "spec: {{.Spec}}"
 			t.Error("expected zero FromSpec when section omitted")
 		}
 	})
+
+	t.Run("default diff base is origin/main", func(t *testing.T) {
+		cfg, err := Load(t.TempDir())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Diff.Base != "origin/main" {
+			t.Errorf("Diff.Base = %q, want %q", cfg.Diff.Base, "origin/main")
+		}
+	})
+
+	t.Run("custom diff base is loaded", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, ".treepad.toml"), "[diff]\nbase = \"master\"\n")
+		cfg, err := Load(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Diff.Base != "master" {
+			t.Errorf("Diff.Base = %q, want %q", cfg.Diff.Base, "master")
+		}
+	})
+
+	t.Run("omitting diff section retains origin/main default", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, ".treepad.toml"), "[sync]\ninclude = [\"a.txt\"]\n")
+		cfg, err := Load(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Diff.Base != "origin/main" {
+			t.Errorf("Diff.Base = %q, want %q", cfg.Diff.Base, "origin/main")
+		}
+	})
 }
 
 func TestDefaultSyncInclude(t *testing.T) {

--- a/internal/treepad/diff.go
+++ b/internal/treepad/diff.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"treepad/internal/config"
 	"treepad/internal/worktree"
 )
 
@@ -23,10 +24,6 @@ func Diff(ctx context.Context, d Deps, in DiffInput) error {
 	if in.Branch == "" {
 		return fmt.Errorf("branch name is required")
 	}
-	base := in.Base
-	if base == "" {
-		base = "main"
-	}
 
 	wts, err := listWorktrees(ctx, d)
 	if err != nil {
@@ -38,6 +35,11 @@ func Diff(ctx context.Context, d Deps, in DiffInput) error {
 	}
 	if target.Prunable {
 		return fmt.Errorf("worktree for %q is prunable (%s); run `tp prune`", in.Branch, target.PrunableReason)
+	}
+
+	base := in.Base
+	if base == "" {
+		base = resolveBase(wts)
 	}
 
 	refs := base + "...HEAD"
@@ -64,4 +66,15 @@ func Diff(ctx context.Context, d Deps, in DiffInput) error {
 		return fmt.Errorf("git diff: %w", err)
 	}
 	return nil
+}
+
+// resolveBase returns the base ref for diffing, loading from config when
+// available. Falls back to "origin/main".
+func resolveBase(wts []worktree.Worktree) string {
+	if main, err := worktree.MainWorktree(wts); err == nil {
+		if cfg, err := config.Load(main.Path); err == nil {
+			return cfg.Diff.Base
+		}
+	}
+	return "origin/main"
 }

--- a/internal/treepad/diff_test.go
+++ b/internal/treepad/diff_test.go
@@ -11,6 +11,17 @@ import (
 	"treepad/internal/ui"
 )
 
+// makeMainWorktree creates a temp dir with a .git subdirectory so that
+// worktree.isMainWorktree recognises it as the primary worktree.
+func makeMainWorktree(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
 func TestDiff(t *testing.T) {
 	t.Run("requires branch", func(t *testing.T) {
 		d := Deps{Runner: fakeRunner{}, Syncer: &fakeSyncer{}, Out: &bytes.Buffer{}, Log: ui.New(&bytes.Buffer{}), In: strings.NewReader("")}
@@ -44,8 +55,8 @@ func TestDiff(t *testing.T) {
 		wantArgs  []string
 	}{
 		{
-			name:     "default base is main",
-			wantArgs: []string{"diff", "main...HEAD"},
+			name:     "default base is origin/main",
+			wantArgs: []string{"diff", "origin/main...HEAD"},
 		},
 		{
 			name:     "custom base",
@@ -55,7 +66,7 @@ func TestDiff(t *testing.T) {
 		{
 			name:      "extra args forwarded",
 			extraArgs: []string{"--stat"},
-			wantArgs:  []string{"diff", "main...HEAD", "--stat"},
+			wantArgs:  []string{"diff", "origin/main...HEAD", "--stat"},
 		},
 	}
 	for _, tt := range streamTests {
@@ -83,6 +94,27 @@ func TestDiff(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("base from config overrides default", func(t *testing.T) {
+		mainPath := makeMainWorktree(t)
+		if err := os.WriteFile(filepath.Join(mainPath, ".treepad.toml"), []byte("[diff]\nbase = \"master\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		featPath := t.TempDir()
+		pt := &fakePassthroughRunner{}
+		d := Deps{Runner: fakeRunner{output: twoWorktreePorcelainWithMain(mainPath, featPath)}, Syncer: &fakeSyncer{}, Out: &bytes.Buffer{}, Log: ui.New(&bytes.Buffer{}), In: strings.NewReader("")}
+
+		if err := Diff(context.Background(), d, DiffInput{Branch: "feat", Runner: pt}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(pt.calls) == 0 {
+			t.Fatal("expected passthrough runner call, got none")
+		}
+		wantArgs := []string{"diff", "master...HEAD"}
+		if !equalStringSlice(pt.calls[0].args, wantArgs) {
+			t.Errorf("args = %v, want %v", pt.calls[0].args, wantArgs)
+		}
+	})
 
 	t.Run("file output writes plain patch", func(t *testing.T) {
 		dir := t.TempDir()

--- a/internal/treepad/tty_e2e.go
+++ b/internal/treepad/tty_e2e.go
@@ -1,0 +1,11 @@
+//go:build e2e
+
+package treepad
+
+import "os"
+
+// Disable the /dev/tty fallback in e2e builds so osPassthroughRunner routes
+// subprocess stdio to os.Stdout/Stderr, which testscript can capture.
+func init() {
+	openTTY = func() *os.File { return nil }
+}

--- a/internal/treepad/ui.go
+++ b/internal/treepad/ui.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"os/exec"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -48,6 +49,10 @@ type (
 	uiOpenDoneMsg struct {
 		path string
 		err  error
+	}
+	uiDiffDoneMsg struct {
+		branch string
+		err    error
 	}
 	uiYankClearMsg struct{}
 )
@@ -172,6 +177,15 @@ func (m uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.toast = &uiToast{msg: fmt.Sprintf("✓ opened %s", msg.path)}
 		return m, m.doToastTimer()
 
+	case uiDiffDoneMsg:
+		m.actionInFlight = false
+		if msg.err != nil {
+			m.toast = &uiToast{msg: fmt.Sprintf("%v", msg.err), isErr: true}
+			return m, nil
+		}
+		m.toast = &uiToast{msg: fmt.Sprintf("✓ diffed %s", msg.branch)}
+		return m, m.doToastTimer()
+
 	case uiYankClearMsg:
 		m.yankPath = ""
 
@@ -260,6 +274,15 @@ func (m uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.toast = nil
 				return m, m.doOpen(m.rows[m.cursor])
 			}
+		case "d":
+			if !m.actionInFlight && len(m.rows) > 0 {
+				row := m.rows[m.cursor]
+				if !row.Prunable {
+					m.actionInFlight = true
+					m.toast = nil
+					return m, m.doDiff(row)
+				}
+			}
 		case "y":
 			if len(m.rows) > 0 {
 				path := m.rows[m.cursor].Path
@@ -337,6 +360,26 @@ func (m uiModel) doOpen(row StatusRow) tea.Cmd {
 		err = m.d.Opener.Open(m.ctx, spec, data)
 		return uiOpenDoneMsg{path: openPath, err: err}
 	}
+}
+
+func (m uiModel) doDiff(row StatusRow) tea.Cmd {
+	var mainPath string
+	for _, r := range m.rows {
+		if r.IsMain {
+			mainPath = r.Path
+			break
+		}
+	}
+	base := "origin/main"
+	if mainPath != "" {
+		if cfg, err := config.Load(mainPath); err == nil {
+			base = cfg.Diff.Base
+		}
+	}
+	cmd := exec.Command("git", "-C", row.Path, "diff", base+"...HEAD")
+	return tea.ExecProcess(cmd, func(err error) tea.Msg {
+		return uiDiffDoneMsg{branch: row.Branch, err: err}
+	})
 }
 
 func (m uiModel) doSync(branch string) tea.Cmd {
@@ -506,6 +549,7 @@ func uiRenderHelp() string {
 		"s           Sync selected worktree (config + artifact)\n" +
 		"S           Sync all worktrees\n" +
 		"o           Open artifact for selected worktree\n" +
+		"d           Diff selected worktree against base (default origin/main)\n" +
 		"y           Yank path of selected worktree (OSC-52)\n" +
 		"r           Remove selected worktree (with confirmation)\n" +
 		"p           Prune merged worktrees (with confirmation)\n" +


### PR DESCRIPTION
## Summary

- Adds a `d` key binding to `tp ui`: suspends the alt-screen via `tea.ExecProcess`, runs `git diff <base>...HEAD` with inherited stdio so the user's pager (delta/diff-so-fancy/less) handles rendering, then returns to the TUI
- Works on all rows including the default (`main *`) worktree
- Adds `[diff] base` config field in `.treepad.toml` (default `"origin/main"`), respected by both the TUI binding and `tp diff` CLI — which previously hardcoded `"main"`

## Test plan

- [ ] `go test ./...` passes (372 tests)
- [ ] `tp ui` → press `d` on a feature branch → pager shows diff → `q` returns to TUI with `✓ diffed <branch>` toast
- [ ] Same on the `main *` row — shows unpushed commits or empty diff
- [ ] Add `[diff] base = "master"` to `.treepad.toml` → both `tp diff` and TUI `d` use `master`
- [ ] Press `?` → help overlay lists `d`
- [ ] Press `d` on a prunable row → no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)