### PR TITLE
feat: tp cd -

### DIFF
--- a/internal/commands/shell_init.go
+++ b/internal/commands/shell_init.go
@@ -12,10 +12,22 @@ import (
 // in real time and interactive children (e.g. claude) inherit a real TTY.
 // TREEPAD_CD_FD=3 tells tp to write the __TREEPAD_CD__ directive to fd 3, which
 // is redirected into the $(...) capture so only that payload is captured.
+// TP_PREV_WORKTREE tracks the last directory before a tp-initiated cd, enabling
+// `tp cd -` to toggle between two worktrees.
 const shellFunc = `tp() {
   local cd_path rc
+  if [ "$1" = "cd" ] && [ "$2" = "-" ]; then
+    [ -z "$TP_PREV_WORKTREE" ] && { printf 'tp: no previous worktree\n' >&2; return 1; }
+    local _prev="$TP_PREV_WORKTREE"
+    TP_PREV_WORKTREE="$PWD"
+    cd -- "$_prev"
+    return $?
+  fi
   cd_path="$(TREEPAD_CD_FD=3 command tp "$@" 3>&1 1>&4)"; rc=$?
-  [ -n "$cd_path" ] && cd -- "$cd_path"
+  if [ -n "$cd_path" ]; then
+    TP_PREV_WORKTREE="$PWD"
+    cd -- "$cd_path"
+  fi
   return $rc
 } 4>&1`
 

--- a/internal/commands/shell_init_test.go
+++ b/internal/commands/shell_init_test.go
@@ -24,7 +24,7 @@ func TestShellInitCommand(t *testing.T) {
 	}
 
 	out := buf.String()
-	for _, want := range []string{"tp()", "TREEPAD_CD_FD=3", "3>&1 1>&4"} {
+	for _, want := range []string{"tp()", "TREEPAD_CD_FD=3", "3>&1 1>&4", "TP_PREV_WORKTREE", `"cd" ] && [ "$2" = "-"`} {
 		if !strings.Contains(out, want) {
 			t.Errorf("shell-init output missing %q; got:\n%s", want, out)
 		}


### PR DESCRIPTION
Adds `tp cd -` to toggle between the two most recently visited worktrees, mirroring shell `cd -` muscle memory.

## How it works

All logic lives in the shell function (`shell-init`); no Go binary changes needed.

- Any successful tp-emitted cd now saves `$PWD` to `TP_PREV_WORKTREE` before jumping.
- `tp cd -` is intercepted before calling the binary: swaps `TP_PREV_WORKTREE` with `$PWD` and cds directly. Errors clearly if no previous worktree exists in the session.
- Toggle semantics are correct — `tp cd -` twice returns to the original location.
- Covers all tp navigation entry points: `tp cd`, `tp new`, and `tp ui` Enter.

Users need to re-source `eval "$(tp shell-init)"` to pick up the change.