### PR TITLE
refactor(exec): fs.FS-driven detection, pure parsers, Detect→Resolve

### DIFF
--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -57,10 +57,13 @@ func pickRunner(fsys fs.FS, override string) (string, error) {
 	}
 
 	if len(detected) == 0 {
-		return "", fmt.Errorf("no task runner detected; check that a justfile, package.json, Makefile, or pyproject.toml is present")
+		return "", fmt.Errorf("no task runner detected; check that a justfile, " +
+			"package.json, Makefile, or pyproject.toml is present")
 	}
 	if len(detected) > 1 {
-		return "", fmt.Errorf("multiple task runners detected (%s); set [exec]\nrunner = %q (or another) in .treepad.toml to disambiguate", strings.Join(detected, ", "), detected[0])
+		return "", fmt.Errorf(
+			"multiple task runners detected (%s); set [exec]\nrunner = %q (or another) in .treepad.toml to disambiguate",
+			strings.Join(detected, ", "), detected[0])
 	}
 	return detected[0], nil
 }

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -4,8 +4,8 @@ package exec
 import (
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -21,79 +21,193 @@ type Runner struct {
 	Scripts   []string // enumerated script names (sorted)
 }
 
-// Detect identifies the task runner in worktreePath and returns it.
-// override, if non-empty, forces use of the named runner (from .treepad.toml [exec] runner).
-// Returns an error if multiple runners are detected and override is empty.
-func Detect(worktreePath, override string) (Runner, error) {
+// Resolve detects the task runner in dir (or forces override if non-empty),
+// enumerates its scripts, and returns a fully-populated Runner.
+func Resolve(dir, override string) (Runner, error) {
+	fsys := os.DirFS(dir)
+	name, err := pickRunner(fsys, override)
+	if err != nil {
+		return Runner{}, err
+	}
+	scripts, err := enumerate(fsys, name)
+	if err != nil {
+		return Runner{}, err
+	}
+	return Runner{Name: name, ScriptCmd: scriptCmd(name), Scripts: scripts}, nil
+}
+
+func pickRunner(fsys fs.FS, override string) (string, error) {
 	if override != "" {
-		scripts, err := listScripts(worktreePath, override)
-		if err != nil {
-			return Runner{}, err
-		}
-		return Runner{
-			Name:      override,
-			ScriptCmd: scriptCmd(override),
-			Scripts:   scripts,
-		}, nil
+		return override, nil
 	}
 
 	var detected []string
 
-	if hasFile(worktreePath, "justfile") || hasFile(worktreePath, "Justfile") {
+	if hasFile(fsys, "justfile") || hasFile(fsys, "Justfile") {
 		detected = append(detected, "just")
 	}
-	if hasFile(worktreePath, "package.json") {
-		jsRunner, err := detectJSManager(worktreePath)
-		if err != nil {
-			return Runner{}, err
-		}
-		detected = append(detected, jsRunner)
+	if hasFile(fsys, "package.json") {
+		detected = append(detected, detectJSManager(fsys))
 	}
-	if hasFile(worktreePath, "Makefile") {
+	if hasFile(fsys, "Makefile") {
 		detected = append(detected, "make")
 	}
-	if hasFile(worktreePath, "pyproject.toml") {
-		detected = append(detected, detectPythonRunner(worktreePath))
+	if hasFile(fsys, "pyproject.toml") {
+		detected = append(detected, detectPythonRunner(fsys))
 	}
 
 	if len(detected) == 0 {
-		return Runner{}, fmt.Errorf("no task runner detected; check that a justfile, " +
-			"package.json, Makefile, or pyproject.toml is present")
+		return "", fmt.Errorf("no task runner detected; check that a justfile, package.json, Makefile, or pyproject.toml is present")
 	}
 	if len(detected) > 1 {
-		return Runner{}, fmt.Errorf(
-			"multiple task runners detected (%s); set [exec]\nrunner = %q (or another) in .treepad.toml to disambiguate",
-			strings.Join(detected, ", "), detected[0],
-		)
+		return "", fmt.Errorf("multiple task runners detected (%s); set [exec]\nrunner = %q (or another) in .treepad.toml to disambiguate", strings.Join(detected, ", "), detected[0])
 	}
-
-	name := detected[0]
-	scripts, err := listScripts(worktreePath, name)
-	if err != nil {
-		return Runner{}, err
-	}
-	return Runner{
-		Name:      name,
-		ScriptCmd: scriptCmd(name),
-		Scripts:   scripts,
-	}, nil
+	return detected[0], nil
 }
 
-// listScripts returns the known script names for the named runner in worktreePath.
-// Returns nil for runners that do not support script enumeration (make, pip).
-func listScripts(worktreePath, runnerName string) ([]string, error) {
-	switch runnerName {
+func enumerate(fsys fs.FS, name string) ([]string, error) {
+	switch name {
 	case "just":
-		return listJustRecipes(worktreePath)
-	case "npm", "pnpm", "yarn", "bun":
-		return listPackageJSONScripts(worktreePath)
-	case "poetry", "uv", "pip":
-		return listPyprojectScripts(worktreePath)
-	case "make":
+		for _, fname := range []string{"justfile", "Justfile"} {
+			data, err := fs.ReadFile(fsys, fname)
+			if err == nil {
+				return parseJustRecipes(data), nil
+			}
+		}
 		return nil, nil
+	case "npm", "pnpm", "yarn", "bun":
+		data, err := fs.ReadFile(fsys, "package.json")
+		if err != nil {
+			return nil, fmt.Errorf("read package.json: %w", err)
+		}
+		return parsePackageScripts(data)
+	case "poetry", "uv", "pip":
+		data, err := fs.ReadFile(fsys, "pyproject.toml")
+		if err != nil {
+			return nil, fmt.Errorf("read pyproject.toml: %w", err)
+		}
+		return parsePyprojectScripts(data)
 	default:
 		return nil, nil
 	}
+}
+
+func hasFile(fsys fs.FS, name string) bool {
+	f, err := fsys.Open(name)
+	if err != nil {
+		return false
+	}
+	_ = f.Close()
+	return true
+}
+
+func detectJSManager(fsys fs.FS) string {
+	switch {
+	case hasFile(fsys, "bun.lockb"):
+		return "bun"
+	case hasFile(fsys, "pnpm-lock.yaml"):
+		return "pnpm"
+	case hasFile(fsys, "yarn.lock"):
+		return "yarn"
+	case hasFile(fsys, "package-lock.json"):
+		return "npm"
+	}
+	data, err := fs.ReadFile(fsys, "package.json")
+	if err != nil {
+		return "npm"
+	}
+	return parsePackageManagerField(data)
+}
+
+func detectPythonRunner(fsys fs.FS) string {
+	data, err := fs.ReadFile(fsys, "pyproject.toml")
+	if err != nil {
+		return "uv"
+	}
+	if strings.Contains(string(data), "[tool.poetry]") {
+		return "poetry"
+	}
+	return "uv"
+}
+
+// justRecipeRe matches lines that begin with an identifier followed by a colon.
+// Variable assignments (name := value) are excluded post-match by checking the
+// character immediately after the colon.
+var justRecipeRe = regexp.MustCompile(`(?m)^([a-zA-Z0-9][a-zA-Z0-9_-]*)[^:\n]*:`)
+
+func parseJustRecipes(data []byte) []string {
+	var recipes []string
+	for _, idx := range justRecipeRe.FindAllSubmatchIndex(data, -1) {
+		// idx[1] is the position after the colon; skip if followed by '=' (:= assignment).
+		if idx[1] < len(data) && data[idx[1]] == '=' {
+			continue
+		}
+		recipe := string(data[idx[2]:idx[3]])
+		if strings.HasPrefix(recipe, "_") {
+			continue
+		}
+		recipes = append(recipes, recipe)
+	}
+	sort.Strings(recipes)
+	return recipes
+}
+
+func parsePackageScripts(data []byte) ([]string, error) {
+	var pkg struct {
+		Scripts map[string]string `json:"scripts"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return nil, fmt.Errorf("parse package.json: %w", err)
+	}
+	scripts := make([]string, 0, len(pkg.Scripts))
+	for name := range pkg.Scripts {
+		scripts = append(scripts, name)
+	}
+	sort.Strings(scripts)
+	return scripts, nil
+}
+
+func parsePackageManagerField(data []byte) string {
+	var pkg struct {
+		PackageManager string `json:"packageManager"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil || pkg.PackageManager == "" {
+		return "npm"
+	}
+	name, _, _ := strings.Cut(pkg.PackageManager, "@")
+	switch name {
+	case "npm", "pnpm", "yarn", "bun":
+		return name
+	}
+	return "npm"
+}
+
+type pyprojectTOML struct {
+	Project struct {
+		Scripts map[string]string `toml:"scripts"`
+	} `toml:"project"`
+	Tool struct {
+		Poetry struct {
+			Scripts map[string]string `toml:"scripts"`
+		} `toml:"poetry"`
+	} `toml:"tool"`
+}
+
+func parsePyprojectScripts(data []byte) ([]string, error) {
+	var py pyprojectTOML
+	if _, err := toml.Decode(string(data), &py); err != nil {
+		return nil, fmt.Errorf("parse pyproject.toml: %w", err)
+	}
+	scriptMap := py.Project.Scripts
+	if len(scriptMap) == 0 {
+		scriptMap = py.Tool.Poetry.Scripts
+	}
+	scripts := make([]string, 0, len(scriptMap))
+	for name := range scriptMap {
+		scripts = append(scripts, name)
+	}
+	sort.Strings(scripts)
+	return scripts, nil
 }
 
 func scriptCmd(runner string) []string {
@@ -117,133 +231,4 @@ func scriptCmd(runner string) []string {
 	default:
 		return []string{runner}
 	}
-}
-
-func hasFile(dir, name string) bool {
-	_, err := os.Stat(filepath.Join(dir, name))
-	return err == nil
-}
-
-// detectJSManager selects npm/pnpm/yarn/bun based on lockfile presence,
-// then the packageManager field in package.json, defaulting to npm.
-func detectJSManager(dir string) (string, error) {
-	switch {
-	case hasFile(dir, "bun.lockb"):
-		return "bun", nil
-	case hasFile(dir, "pnpm-lock.yaml"):
-		return "pnpm", nil
-	case hasFile(dir, "yarn.lock"):
-		return "yarn", nil
-	case hasFile(dir, "package-lock.json"):
-		return "npm", nil
-	}
-
-	data, err := os.ReadFile(filepath.Join(dir, "package.json"))
-	if err != nil {
-		return "npm", nil
-	}
-	var pkg struct {
-		PackageManager string `json:"packageManager"`
-	}
-	if jsonErr := json.Unmarshal(data, &pkg); jsonErr == nil && pkg.PackageManager != "" {
-		name, _, _ := strings.Cut(pkg.PackageManager, "@")
-		switch name {
-		case "npm", "pnpm", "yarn", "bun":
-			return name, nil
-		}
-	}
-	return "npm", nil
-}
-
-// detectPythonRunner picks poetry or uv based on pyproject.toml contents.
-func detectPythonRunner(dir string) string {
-	data, err := os.ReadFile(filepath.Join(dir, "pyproject.toml"))
-	if err != nil {
-		return "uv"
-	}
-	if strings.Contains(string(data), "[tool.poetry]") {
-		return "poetry"
-	}
-	return "uv"
-}
-
-// justRecipeRe matches lines that look like recipe definitions (starts with an
-// identifier then anything up to a colon). Post-filtered to exclude ":="
-// variable assignments since Go's regexp doesn't support negative lookaheads.
-var justRecipeRe = regexp.MustCompile(`(?m)^([a-zA-Z0-9][a-zA-Z0-9_-]*)[^:\n]*:`)
-
-func listJustRecipes(dir string) ([]string, error) {
-	for _, name := range []string{"justfile", "Justfile"} {
-		data, err := os.ReadFile(filepath.Join(dir, name))
-		if os.IsNotExist(err) {
-			continue
-		}
-		if err != nil {
-			return nil, fmt.Errorf("read %s: %w", name, err)
-		}
-		var recipes []string
-		for _, m := range justRecipeRe.FindAllStringSubmatch(string(data), -1) {
-			recipe := m[1]
-			fullMatch := m[0]
-			// Exclude variable assignments (name := value) and private recipes.
-			if strings.Contains(fullMatch, ":=") || strings.HasPrefix(recipe, "_") {
-				continue
-			}
-			recipes = append(recipes, recipe)
-		}
-		sort.Strings(recipes)
-		return recipes, nil
-	}
-	return nil, nil
-}
-
-func listPackageJSONScripts(dir string) ([]string, error) {
-	data, err := os.ReadFile(filepath.Join(dir, "package.json"))
-	if err != nil {
-		return nil, fmt.Errorf("read package.json: %w", err)
-	}
-	var pkg struct {
-		Scripts map[string]string `json:"scripts"`
-	}
-	if err := json.Unmarshal(data, &pkg); err != nil {
-		return nil, fmt.Errorf("parse package.json: %w", err)
-	}
-	scripts := make([]string, 0, len(pkg.Scripts))
-	for name := range pkg.Scripts {
-		scripts = append(scripts, name)
-	}
-	sort.Strings(scripts)
-	return scripts, nil
-}
-
-type pyprojectTOML struct {
-	Project struct {
-		Scripts map[string]string `toml:"scripts"`
-	} `toml:"project"`
-	Tool struct {
-		Poetry struct {
-			Scripts map[string]string `toml:"scripts"`
-		} `toml:"poetry"`
-	} `toml:"tool"`
-}
-
-func listPyprojectScripts(dir string) ([]string, error) {
-	data, err := os.ReadFile(filepath.Join(dir, "pyproject.toml"))
-	if err != nil {
-		return nil, fmt.Errorf("read pyproject.toml: %w", err)
-	}
-	var py pyprojectTOML
-	if _, err := toml.Decode(string(data), &py); err != nil {
-		return nil, fmt.Errorf("parse pyproject.toml: %w", err)
-	}
-	scriptMap := py.Project.Scripts
-	if len(scriptMap) == 0 {
-		scriptMap = py.Tool.Poetry.Scripts
-	}
-	scripts := make([]string, 0, len(scriptMap))
-	for name := range scriptMap {
-		scripts = append(scripts, name)
-	}
-	sort.Strings(scripts)
-	return scripts, nil
 }

--- a/internal/exec/runner_test.go
+++ b/internal/exec/runner_test.go
@@ -125,9 +125,10 @@ func TestParsePyprojectScripts(t *testing.T) {
 			want:  []string{"run"},
 		},
 		{
-			name:  "project scripts take precedence over poetry scripts",
-			input: "[project]\nname = \"x\"\n\n[project.scripts]\nserve = \"x:serve\"\n\n[tool.poetry.scripts]\nbuild = \"x:build\"\n",
-			want:  []string{"serve"},
+			name: "project scripts take precedence over poetry scripts",
+			input: "[project]\nname = \"x\"\n\n[project.scripts]\nserve = \"x:serve\"\n\n" +
+				"[tool.poetry.scripts]\nbuild = \"x:build\"\n",
+			want: []string{"serve"},
 		},
 		{
 			name:  "empty file",
@@ -343,8 +344,10 @@ func TestResolve(t *testing.T) {
 			wantName: "make",
 		},
 		{
-			name:        "poetry",
-			files:       map[string]string{"pyproject.toml": "[tool.poetry]\nname = \"x\"\n\n[tool.poetry.scripts]\nmyapp = \"myapp.cli:main\"\n"},
+			name: "poetry",
+			files: map[string]string{
+				"pyproject.toml": "[tool.poetry]\nname = \"x\"\n\n[tool.poetry.scripts]\nmyapp = \"myapp.cli:main\"\n",
+			},
 			wantName:    "poetry",
 			wantScripts: []string{"myapp"},
 		},

--- a/internal/exec/runner_test.go
+++ b/internal/exec/runner_test.go
@@ -4,128 +4,94 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/fstest"
 )
 
-func writeFile(t *testing.T, dir, name, content string) {
-	t.Helper()
-	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
-		t.Fatalf("write %s: %v", name, err)
+// --- Tier 1: pure parser tests ---
+
+func TestParseJustRecipes(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "basic recipes",
+			input: "build:\n\tgo build ./...\ntest:\n\tgo test ./...\n",
+			want:  []string{"build", "test"},
+		},
+		{
+			name:  "private recipe excluded",
+			input: "build:\n\tgo build\n_hidden:\n\techo secret\n",
+			want:  []string{"build"},
+		},
+		{
+			name:  "variable assignment with space excluded",
+			input: "X := 1\nbuild:\n\tgo build\n",
+			want:  []string{"build"},
+		},
+		{
+			name:  "variable assignment without space excluded",
+			input: "x:=value\nbuild:\n\tgo build\n",
+			want:  []string{"build"},
+		},
+		{
+			name:  "recipe with default args",
+			input: "build target='debug':\n\tgo build -tags {{target}}\ntest:\n\tgo test\n",
+			want:  []string{"build", "test"},
+		},
+		{
+			name:  "sorted output",
+			input: "z:\n\tz\na:\n\ta\nm:\n\tm\n",
+			want:  []string{"a", "m", "z"},
+		},
+		{
+			name:  "empty file",
+			input: "",
+			want:  nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseJustRecipes([]byte(tt.input))
+			if !equalStrSlice(got, tt.want) {
+				t.Errorf("parseJustRecipes() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 
-func TestDetect(t *testing.T) {
+func TestParsePackageScripts(t *testing.T) {
 	tests := []struct {
-		name     string
-		files    map[string]string
-		override string
-		wantName string
-		wantErr  bool
-		// wantScripts, if non-nil, asserts Scripts exactly.
-		wantScripts []string
-		// wantNoScripts asserts Scripts is empty (for make).
-		wantNoScripts bool
+		name    string
+		input   string
+		want    []string
+		wantErr bool
 	}{
 		{
-			name: "just",
-			files: map[string]string{
-				"justfile": "build:\n  go build ./...\ntest:\n  go test ./...\n_private:\n  echo secret\n",
-			},
-			wantName:    "just",
-			wantScripts: []string{"build", "test"},
+			name:  "basic scripts sorted",
+			input: `{"scripts":{"build":"tsc","test":"jest"}}`,
+			want:  []string{"build", "test"},
 		},
 		{
-			name: "justfile capitalised",
-			files: map[string]string{
-				"Justfile": "lint:\n  golangci-lint run\n",
-			},
-			wantName: "just",
+			name:  "empty scripts map",
+			input: `{"scripts":{}}`,
+			want:  []string{},
 		},
 		{
-			name: "package.json with bun lockfile",
-			files: map[string]string{
-				"package.json": `{"scripts":{"dev":"vite","build":"vite build"}}`,
-				"bun.lockb":    "",
-			},
-			wantName:    "bun",
-			wantScripts: []string{"build", "dev"},
+			name:  "no scripts field",
+			input: `{}`,
+			want:  []string{},
 		},
 		{
-			name: "package.json with pnpm lockfile",
-			files: map[string]string{
-				"package.json":   `{"scripts":{"start":"node index.js"}}`,
-				"pnpm-lock.yaml": "",
-			},
-			wantName: "pnpm",
-		},
-		{
-			name: "package.json with packageManager field",
-			files: map[string]string{
-				"package.json": `{"packageManager":"yarn@4.0.0","scripts":{"build":"tsc"}}`,
-			},
-			wantName: "yarn",
-		},
-		{
-			name: "package.json defaults to npm",
-			files: map[string]string{
-				"package.json": `{"scripts":{"test":"jest"}}`,
-			},
-			wantName: "npm",
-		},
-		{
-			name: "pyproject.toml poetry",
-			files: map[string]string{
-				"pyproject.toml": "[tool.poetry]\nname = \"myapp\"\n\n[tool.poetry.scripts]\nmyapp = \"myapp.cli:main\"\n",
-			},
-			wantName:    "poetry",
-			wantScripts: []string{"myapp"},
-		},
-		{
-			name: "pyproject.toml uv",
-			files: map[string]string{
-				"pyproject.toml": "[project]\nname = \"myapp\"\n\n[project.scripts]\nrun = \"myapp.main:main\"\n",
-			},
-			wantName: "uv",
-		},
-		{
-			name: "make",
-			files: map[string]string{
-				"Makefile": "build:\n\tgo build ./...\n",
-			},
-			wantName:      "make",
-			wantNoScripts: true,
-		},
-		{
-			name: "ambiguous runners error",
-			files: map[string]string{
-				"justfile":     "build:\n  go build\n",
-				"package.json": `{"scripts":{"build":"tsc"}}`,
-			},
+			name:    "invalid JSON",
+			input:   `{broken`,
 			wantErr: true,
-		},
-		{
-			name:    "no runner found error",
-			files:   map[string]string{},
-			wantErr: true,
-		},
-		{
-			name: "override selects runner despite ambiguity",
-			files: map[string]string{
-				"package.json": `{"scripts":{"test":"jest"}}`,
-				"justfile":     "check:\n  go vet ./...\n",
-			},
-			override: "just",
-			wantName: "just",
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dir := t.TempDir()
-			for name, content := range tt.files {
-				writeFile(t, dir, name, content)
-			}
-
-			r, err := Detect(dir, tt.override)
+			got, err := parsePackageScripts([]byte(tt.input))
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -135,32 +101,292 @@ func TestDetect(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
+			if !equalStrSlice(got, tt.want) {
+				t.Errorf("parsePackageScripts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParsePyprojectScripts(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "poetry scripts",
+			input: "[tool.poetry]\nname = \"myapp\"\n\n[tool.poetry.scripts]\nmyapp = \"myapp.cli:main\"\n",
+			want:  []string{"myapp"},
+		},
+		{
+			name:  "project scripts",
+			input: "[project]\nname = \"myapp\"\n\n[project.scripts]\nrun = \"myapp.main:main\"\n",
+			want:  []string{"run"},
+		},
+		{
+			name:  "project scripts take precedence over poetry scripts",
+			input: "[project]\nname = \"x\"\n\n[project.scripts]\nserve = \"x:serve\"\n\n[tool.poetry.scripts]\nbuild = \"x:build\"\n",
+			want:  []string{"serve"},
+		},
+		{
+			name:  "empty file",
+			input: "",
+			want:  []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePyprojectScripts([]byte(tt.input))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !equalStrSlice(got, tt.want) {
+				t.Errorf("parsePyprojectScripts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParsePackageManagerField(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"pnpm with version", `{"packageManager":"pnpm@9.0.0"}`, "pnpm"},
+		{"yarn with version", `{"packageManager":"yarn@4.0.0"}`, "yarn"},
+		{"bun with version", `{"packageManager":"bun@1.0.0"}`, "bun"},
+		{"npm with version", `{"packageManager":"npm@10.0.0"}`, "npm"},
+		{"unknown manager defaults to npm", `{"packageManager":"deno@1.0.0"}`, "npm"},
+		{"empty field defaults to npm", `{"packageManager":""}`, "npm"},
+		{"no field defaults to npm", `{}`, "npm"},
+		{"invalid JSON defaults to npm", `{broken`, "npm"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parsePackageManagerField([]byte(tt.input))
+			if got != tt.want {
+				t.Errorf("parsePackageManagerField() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- Tier 2: detection tests via fstest.MapFS ---
+
+func TestPickRunner(t *testing.T) {
+	tests := []struct {
+		name     string
+		files    fstest.MapFS
+		override string
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:  "justfile",
+			files: fstest.MapFS{"justfile": {}},
+			want:  "just",
+		},
+		{
+			name:  "Justfile capitalised",
+			files: fstest.MapFS{"Justfile": {}},
+			want:  "just",
+		},
+		{
+			name:  "package.json defaults to npm",
+			files: fstest.MapFS{"package.json": {Data: []byte(`{}`)}},
+			want:  "npm",
+		},
+		{
+			name:  "Makefile",
+			files: fstest.MapFS{"Makefile": {}},
+			want:  "make",
+		},
+		{
+			name:  "pyproject.toml uv",
+			files: fstest.MapFS{"pyproject.toml": {Data: []byte("[project]\nname = \"x\"\n")}},
+			want:  "uv",
+		},
+		{
+			name:  "pyproject.toml poetry",
+			files: fstest.MapFS{"pyproject.toml": {Data: []byte("[tool.poetry]\nname = \"x\"\n")}},
+			want:  "poetry",
+		},
+		{
+			name: "ambiguous runners error",
+			files: fstest.MapFS{
+				"justfile":     {},
+				"package.json": {Data: []byte(`{}`)},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "no runner error",
+			files:   fstest.MapFS{},
+			wantErr: true,
+		},
+		{
+			name: "override bypasses ambiguity",
+			files: fstest.MapFS{
+				"justfile":     {},
+				"package.json": {Data: []byte(`{}`)},
+			},
+			override: "just",
+			want:     "just",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := pickRunner(tt.files, tt.override)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("pickRunner() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectJSManager(t *testing.T) {
+	tests := []struct {
+		name  string
+		files fstest.MapFS
+		want  string
+	}{
+		{
+			name:  "bun lockfile",
+			files: fstest.MapFS{"bun.lockb": {}, "package.json": {}},
+			want:  "bun",
+		},
+		{
+			name:  "pnpm lockfile",
+			files: fstest.MapFS{"pnpm-lock.yaml": {}, "package.json": {}},
+			want:  "pnpm",
+		},
+		{
+			name:  "yarn lockfile",
+			files: fstest.MapFS{"yarn.lock": {}, "package.json": {}},
+			want:  "yarn",
+		},
+		{
+			name:  "package-lock.json",
+			files: fstest.MapFS{"package-lock.json": {}, "package.json": {}},
+			want:  "npm",
+		},
+		{
+			name:  "packageManager field",
+			files: fstest.MapFS{"package.json": {Data: []byte(`{"packageManager":"pnpm@9"}`)}},
+			want:  "pnpm",
+		},
+		{
+			name:  "lockfile takes precedence over packageManager field",
+			files: fstest.MapFS{"yarn.lock": {}, "package.json": {Data: []byte(`{"packageManager":"pnpm@9"}`)}},
+			want:  "yarn",
+		},
+		{
+			name:  "no lockfile no field defaults to npm",
+			files: fstest.MapFS{"package.json": {Data: []byte(`{}`)}},
+			want:  "npm",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectJSManager(tt.files)
+			if got != tt.want {
+				t.Errorf("detectJSManager() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- Tier 3: Resolve integration tests (pins os.DirFS wiring) ---
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func TestResolve(t *testing.T) {
+	tests := []struct {
+		name        string
+		files       map[string]string
+		override    string
+		wantName    string
+		wantScripts []string
+		wantErr     bool
+	}{
+		{
+			name:        "just",
+			files:       map[string]string{"justfile": "build:\n  go build ./...\ntest:\n  go test ./...\n"},
+			wantName:    "just",
+			wantScripts: []string{"build", "test"},
+		},
+		{
+			name:        "npm",
+			files:       map[string]string{"package.json": `{"scripts":{"build":"tsc","start":"node index.js"}}`},
+			wantName:    "npm",
+			wantScripts: []string{"build", "start"},
+		},
+		{
+			name:     "make",
+			files:    map[string]string{"Makefile": "build:\n\tgo build\n"},
+			wantName: "make",
+		},
+		{
+			name:        "poetry",
+			files:       map[string]string{"pyproject.toml": "[tool.poetry]\nname = \"x\"\n\n[tool.poetry.scripts]\nmyapp = \"myapp.cli:main\"\n"},
+			wantName:    "poetry",
+			wantScripts: []string{"myapp"},
+		},
+		{
+			name:     "override selects runner despite ambiguity",
+			files:    map[string]string{"justfile": "build:\n  go build\n", "package.json": `{"scripts":{}}`},
+			override: "just",
+			wantName: "just",
+		},
+		{
+			name:    "no runner error",
+			files:   map[string]string{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for name, content := range tt.files {
+				writeFile(t, dir, name, content)
+			}
+			r, err := Resolve(dir, tt.override)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Resolve() error = %v", err)
+			}
 			if r.Name != tt.wantName {
 				t.Errorf("Name = %q, want %q", r.Name, tt.wantName)
 			}
 			if tt.wantScripts != nil && !equalStrSlice(r.Scripts, tt.wantScripts) {
 				t.Errorf("Scripts = %v, want %v", r.Scripts, tt.wantScripts)
 			}
-			if tt.wantNoScripts && len(r.Scripts) != 0 {
-				t.Errorf("Scripts should be empty, got %v", r.Scripts)
-			}
 		})
 	}
 }
 
-func TestListScripts_justRecipeWithArgs(t *testing.T) {
-	dir := t.TempDir()
-	writeFile(t, dir, "justfile", "build target='debug':\n  go build -tags {{target}}\ntest:\n  go test\n")
-
-	scripts, err := listScripts(dir, "just")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	want := []string{"build", "test"}
-	if !equalStrSlice(scripts, want) {
-		t.Errorf("Scripts = %v, want %v", scripts, want)
-	}
-}
+// --- Shared helpers ---
 
 func TestScriptCmd(t *testing.T) {
 	tests := []struct {

--- a/internal/treepad/exec.go
+++ b/internal/treepad/exec.go
@@ -104,7 +104,7 @@ func Exec(ctx context.Context, d Deps, in ExecInput) (int, error) {
 		return 0, fmt.Errorf("load config: %w", err)
 	}
 
-	runner, err := tpexec.Detect(wt.Path, cfg.Exec.Runner)
+	runner, err := tpexec.Resolve(wt.Path, cfg.Exec.Runner)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
## Summary

- Renames `Detect` → `Resolve`; `pickRunner` and `enumerate` now take `fs.FS`, with `os.DirFS` called once at the `Resolve` entry point
- Extracts four pure byte-slice parsers (`parseJustRecipes`, `parsePackageScripts`, `parsePyprojectScripts`, `parsePackageManagerField`) — no I/O, easy to unit test
- Fixes a latent bug in `justRecipeRe`: the old `:=` filter checked the regex match string (which ends at the colon), so `X := 1` was never actually excluded; now checks `data[idx[1]] == '='` (char after the colon)
- Rewrites tests in three tiers: pure parser tests (no disk), `fstest.MapFS` detection tests (no temp dirs), minimal `Resolve` integration tests (pins `os.DirFS` wiring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)