### PR TITLE
feat(commands): add consistent flag aliases

### DIFF
--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -28,8 +28,9 @@ func configInitCommand() *cli.Command {
 		Usage: "write a config file with default values",
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
-				Name:  "global",
-				Usage: "write to the global config path instead of .treepad.toml in the main worktree",
+				Name:    "global",
+				Aliases: []string{"g"},
+				Usage:   "write to the global config path instead of .treepad.toml in the main worktree",
 			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {

--- a/internal/commands/doctor.go
+++ b/internal/commands/doctor.go
@@ -14,9 +14,9 @@ func doctorCommand() *cli.Command {
 		Name:  "doctor",
 		Usage: "report cross-worktree health issues (stale, merged-present, remote-gone, config-drift)",
 		Flags: []cli.Flag{
-			&cli.BoolFlag{Name: "json", Usage: "emit JSON instead of a table"},
+			&cli.BoolFlag{Name: "json", Aliases: []string{"j"}, Usage: "emit JSON instead of a table"},
 			&cli.IntFlag{Name: "stale-days", Value: 30, Usage: "flag worktrees with no commit in this many days"},
-			&cli.StringFlag{Name: "base", Value: "main", Usage: "branch to check merges against"},
+			&cli.StringFlag{Name: "base", Aliases: []string{"b"}, Value: "main", Usage: "branch to check merges against"},
 			&cli.BoolFlag{Name: "offline", Usage: "skip remote branch existence check"},
 			&cli.BoolFlag{Name: "strict", Usage: "exit non-zero if any findings are reported"},
 		},

--- a/internal/commands/from_spec.go
+++ b/internal/commands/from_spec.go
@@ -27,9 +27,10 @@ func fromSpecCommand() *cli.Command {
 				Usage:   "`path` to a local markdown spec file (mutually exclusive with --issue)",
 			},
 			&cli.StringFlag{
-				Name:  "base",
-				Usage: "ref to branch the new worktree from",
-				Value: "main",
+				Name:    "base",
+				Aliases: []string{"b"},
+				Usage:   "ref to branch the new worktree from",
+				Value:   "main",
 			},
 			&cli.BoolFlag{
 				Name:    "current",

--- a/internal/commands/from_spec_bulk.go
+++ b/internal/commands/from_spec_bulk.go
@@ -19,6 +19,7 @@ func fromSpecBulkCommand() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:     "issues",
+				Aliases:  []string{"i"},
 				Usage:    "comma-separated issue `numbers`, e.g. \"12,14,19\"",
 				Required: true,
 			},
@@ -27,9 +28,10 @@ func fromSpecBulkCommand() *cli.Command {
 				Usage: "prefix prepended to the slugified issue title for each branch name",
 			},
 			&cli.StringFlag{
-				Name:  "base",
-				Usage: "ref to branch every new worktree from",
-				Value: "main",
+				Name:    "base",
+				Aliases: []string{"b"},
+				Usage:   "ref to branch every new worktree from",
+				Value:   "main",
 			},
 		},
 		Action: runFromSpecBulk,

--- a/internal/commands/new.go
+++ b/internal/commands/new.go
@@ -17,9 +17,10 @@ func newCommand() *cli.Command {
 		ArgsUsage: "<branch>",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:  "base",
-				Usage: "ref to branch the new worktree from",
-				Value: "main",
+				Name:    "base",
+				Aliases: []string{"b"},
+				Usage:   "ref to branch the new worktree from",
+				Value:   "main",
 			},
 			&cli.BoolFlag{
 				Name:    "open",

--- a/internal/commands/prune.go
+++ b/internal/commands/prune.go
@@ -14,9 +14,9 @@ func pruneCommand() *cli.Command {
 		Name:  "prune",
 		Usage: "remove worktrees whose branches are merged into a base branch",
 		Flags: []cli.Flag{
-			&cli.StringFlag{Name: "base", Value: "main", Usage: "base branch to check merges against"},
-			&cli.BoolFlag{Name: "dry-run", Usage: "preview removals without executing"},
-			&cli.BoolFlag{Name: "all", Usage: "force-remove all non-main worktrees (must be run from main)"},
+			&cli.StringFlag{Name: "base", Aliases: []string{"b"}, Value: "main", Usage: "base branch to check merges against"},
+			&cli.BoolFlag{Name: "dry-run", Aliases: []string{"n"}, Usage: "preview removals without executing"},
+			&cli.BoolFlag{Name: "all", Aliases: []string{"a"}, Usage: "force-remove all non-main worktrees (must be run from main)"},
 			&cli.BoolFlag{Name: "yes", Aliases: []string{"y"}, Usage: "skip the confirmation prompt"},
 		},
 		Action: runPrune,

--- a/internal/commands/prune.go
+++ b/internal/commands/prune.go
@@ -16,7 +16,11 @@ func pruneCommand() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{Name: "base", Aliases: []string{"b"}, Value: "main", Usage: "base branch to check merges against"},
 			&cli.BoolFlag{Name: "dry-run", Aliases: []string{"n"}, Usage: "preview removals without executing"},
-			&cli.BoolFlag{Name: "all", Aliases: []string{"a"}, Usage: "force-remove all non-main worktrees (must be run from main)"},
+			&cli.BoolFlag{
+				Name:    "all",
+				Aliases: []string{"a"},
+				Usage:   "force-remove all non-main worktrees (must be run from main)",
+			},
 			&cli.BoolFlag{Name: "yes", Aliases: []string{"y"}, Usage: "skip the confirmation prompt"},
 		},
 		Action: runPrune,

--- a/internal/commands/status.go
+++ b/internal/commands/status.go
@@ -13,7 +13,7 @@ func statusCommand() *cli.Command {
 	return &cli.Command{
 		Name:   "status",
 		Usage:  "list all worktrees with branch, dirty state, ahead/behind, and last-touched",
-		Flags:  []cli.Flag{&cli.BoolFlag{Name: "json", Usage: "emit JSON instead of a table"}},
+		Flags:  []cli.Flag{&cli.BoolFlag{Name: "json", Aliases: []string{"j"}, Usage: "emit JSON instead of a table"}},
 		Action: runStatus,
 	}
 }

--- a/internal/commands/sync.go
+++ b/internal/commands/sync.go
@@ -17,8 +17,8 @@ func syncCommand() *cli.Command {
 		ArgsUsage: "[source-path]",
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
-				Name:    "use-current",
-				Aliases: []string{"c"},
+				Name:    "current",
+				Aliases: []string{"c", "use-current"},
 				Usage:   "use current directory as config source instead of the main worktree",
 			},
 			&cli.BoolFlag{
@@ -40,11 +40,11 @@ func syncCommand() *cli.Command {
 }
 
 func runSync(ctx context.Context, cmd *cli.Command) error {
-	useCurrentFlag := cmd.Bool("use-current")
+	useCurrentFlag := cmd.Bool("current")
 	sourcePath := cmd.Args().First()
 
 	if useCurrentFlag && sourcePath != "" {
-		return fmt.Errorf("--use-current and a source path argument are mutually exclusive")
+		return fmt.Errorf("--current and a source path argument are mutually exclusive")
 	}
 
 	d := treepad.DefaultDeps(cmd.Root().Writer, cmd.Root().ErrWriter, os.Stdin)


### PR DESCRIPTION
## Summary

- `--base`/`-b` now aliased on every command that accepts it (`new`, `from-spec`, `from-spec-bulk`, `doctor`, `prune`) — previously only `diff` had it
- `--json`/`-j` added to `status` and `doctor` 
- `--issues`/`-i` added to `from-spec-bulk`, matching `from-spec --issue`/`-i`
- `prune`: `--dry-run`/`-n`, `--all`/`-a` (unix/make conventions)
- `config init`: `--global`/`-g` (matches `git config --global`)
- `sync --use-current` renamed to `--current` for consistency with `new` and `from-spec`; `--use-current` kept as a legacy alias

## Test plan

- [x] `go build ./... && go test ./...` passes
- [ ] `tp new -b main <branch>`, `tp doctor -j`, `tp prune -n -a`, `tp status -j`, `tp config init -g` each behave identically to their long forms
- [ ] `tp sync --use-current` still works (legacy alias)
- [ ] `tp <cmd> --help` shows new aliases alongside each flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)