### PR TITLE
feat(ui): R key force-removes worktree with confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ tp ui
 | `o` | Open artifact file for selected worktree |
 | `y` | Yank (copy) path of selected worktree to clipboard |
 | `r` | Remove selected worktree (with confirmation) |
+| `R` | Force-remove selected worktree — discards uncommitted changes and unmerged commits (with confirmation) |
 | `p` | Prune merged worktrees (with confirmation) |
 | `?` | Toggle key binding help overlay |
 | `q` / `Ctrl-C` | Quit |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -558,6 +558,7 @@ Renders a full-screen alt-screen display that auto-refreshes every 5 seconds. Sh
 | `d` | Diff selected worktree against base (default from config or `origin/main`) |
 | `y` | Yank (copy) path to clipboard via OSC-52 |
 | `r` | Remove selected worktree (prompts for confirmation) |
+| `R` | Force-remove selected worktree — discards uncommitted changes and unmerged commits (prompts for confirmation) |
 | `p` | Prune merged worktrees (prompts for confirmation) |
 | `?` | Toggle key binding help overlay |
 | `q` / `Ctrl-C` | Quit without cd |
@@ -565,7 +566,7 @@ Renders a full-screen alt-screen display that auto-refreshes every 5 seconds. Sh
 ### Notes
 
 - Requires `eval "$(tp shell-init)"` for `Enter`→cd to take effect in the shell
-- `r` and `p` show an inline confirmation prompt; any key other than `y` cancels
+- `r`, `R`, and `p` show an inline confirmation prompt; any key other than `y` cancels; `R` uses `git worktree remove --force` and `git branch -D` so it succeeds even on dirty or unmerged worktrees
 - While a sync, remove, or prune action is in flight the cursor is locked and a spinner is shown; auto-refresh is paused until the action completes
 - `y` writes the path to the system clipboard via the OSC-52 terminal escape sequence; supported by most modern terminal emulators
 

--- a/e2e/tests/ui_script_force_remove.txtar
+++ b/e2e/tests/ui_script_force_remove.txtar
@@ -1,0 +1,11 @@
+tp-init-repo
+exec tp new feature-x
+# Modify a tracked file to make the worktree dirty — git worktree remove would refuse without --force.
+exec sh -c 'echo modified >> ../repo-feature-x/README.md'
+# Normal CLI remove should fail on the dirty worktree.
+! exec tp remove feature-x
+exists ../repo-feature-x
+# Force-remove via TUI should succeed.
+exec tp ui --script=j,R,y,q
+stdout '✓ removed feature-x'
+! exists ../repo-feature-x

--- a/e2e/tests/ui_script_force_remove_cancel.txtar
+++ b/e2e/tests/ui_script_force_remove_cancel.txtar
@@ -1,0 +1,6 @@
+tp-init-repo
+tp-add-worktree feature-x
+# R opens confirm modal; esc cancels without removing; q exits.
+exec tp ui --script=j,R,esc,q
+! stdout 'removed'
+exists ../repo-feature-x

--- a/e2e/tests/ui_script_help.txtar
+++ b/e2e/tests/ui_script_help.txtar
@@ -2,3 +2,4 @@ tp-init-repo
 exec tp ui --script=?
 stdout 'Key Bindings'
 stdout 'Press any key to dismiss'
+stdout 'Force-remove'

--- a/e2e/tests/ui_script_remove.txtar
+++ b/e2e/tests/ui_script_remove.txtar
@@ -1,0 +1,5 @@
+tp-init-repo
+exec tp new feature-x
+exec tp ui --script=j,r,y,q
+stdout '✓ removed feature-x'
+! exists ../repo-feature-x

--- a/internal/treepad/remove.go
+++ b/internal/treepad/remove.go
@@ -13,6 +13,7 @@ import (
 type RemoveInput struct {
 	Branch    string
 	OutputDir string
+	Force     bool
 	// Cwd overrides os.Getwd for testing the cwd-inside guard.
 	Cwd string
 }
@@ -43,5 +44,5 @@ func Remove(ctx context.Context, d Deps, in RemoveInput) error {
 		return fmt.Errorf("cannot remove the worktree you are currently in; cd elsewhere first")
 	}
 
-	return removeWorktreeAndArtifact(ctx, d, found, rc.Main, rc.OutputDir, false)
+	return removeWorktreeAndArtifact(ctx, d, found, rc.Main, rc.OutputDir, in.Force)
 }

--- a/internal/treepad/remove_test.go
+++ b/internal/treepad/remove_test.go
@@ -201,6 +201,35 @@ func TestRemove(t *testing.T) {
 		})
 	}
 
+	t.Run("force remove passes --force and -D to git", func(t *testing.T) {
+		rr := &recordingRunner{inner: &seqRunner{responses: []runResponse{
+			{output: porcelain}, // git worktree list
+			{},                  // git worktree remove --force
+			{},                  // git branch -D
+		}}}
+		deps := testDeps(rr, &fakeSyncer{}, &fakeOpener{})
+
+		err := Remove(context.Background(), deps, RemoveInput{Branch: "feat", OutputDir: outputDir, Force: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		var foundForce, foundD bool
+		for _, call := range rr.calls {
+			if len(call) >= 4 && call[1] == "worktree" && call[2] == "remove" && call[3] == "--force" {
+				foundForce = true
+			}
+			if len(call) >= 4 && call[1] == "branch" && call[2] == "-D" {
+				foundD = true
+			}
+		}
+		if !foundForce {
+			t.Error("expected git worktree remove --force")
+		}
+		if !foundD {
+			t.Error("expected git branch -D")
+		}
+	})
+
 	t.Run("refuses to remove worktree user is currently in", func(t *testing.T) {
 		runner := &seqRunner{responses: []runResponse{
 			{output: porcelain},

--- a/internal/treepad/ui.go
+++ b/internal/treepad/ui.go
@@ -59,11 +59,12 @@ type (
 type uiMode int
 
 const (
-	uiModeNormal        uiMode = iota
-	uiModeConfirmRemove        // r pressed — awaiting y/cancel
-	uiModeConfirmPrune         // p pressed — awaiting y/cancel
-	uiModeHelp                 // ? pressed — any key dismisses
-	uiModeFilter               // / pressed — typing filter query
+	uiModeNormal             uiMode = iota
+	uiModeConfirmRemove             // r pressed — awaiting y/cancel
+	uiModeConfirmForceRemove        // R pressed — awaiting y/cancel
+	uiModeConfirmPrune              // p pressed — awaiting y/cancel
+	uiModeHelp                      // ? pressed — any key dismisses
+	uiModeFilter                    // / pressed — typing filter query
 )
 
 // uiToast holds a transient message shown below the table.
@@ -306,6 +307,14 @@ func (m uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return m, nil
 				}
 			}
+		case "R":
+			if !m.actionInFlight {
+				if row, ok := m.visibleCursorRow(); ok {
+					m.mode = uiModeConfirmForceRemove
+					m.confirmBranch = row.Branch
+					return m, nil
+				}
+			}
 		case "p":
 			if !m.actionInFlight {
 				m.mode = uiModeConfirmPrune
@@ -388,6 +397,12 @@ func (m uiModel) handleConfirm() (tea.Model, tea.Cmd) {
 		m.confirmBranch = ""
 		m.actionInFlight = true
 		return m, tea.Batch(m.doRemove(branch), m.spinner.Tick)
+	case uiModeConfirmForceRemove:
+		branch := m.confirmBranch
+		m.mode = uiModeNormal
+		m.confirmBranch = ""
+		m.actionInFlight = true
+		return m, tea.Batch(m.doForceRemove(branch), m.spinner.Tick)
 	case uiModeConfirmPrune:
 		m.mode = uiModeNormal
 		m.actionInFlight = true
@@ -401,6 +416,13 @@ func (m uiModel) handleConfirm() (tea.Model, tea.Cmd) {
 func (m uiModel) doRemove(branch string) tea.Cmd {
 	return func() tea.Msg {
 		err := Remove(m.ctx, m.d, RemoveInput{Branch: branch, OutputDir: m.in.OutputDir})
+		return uiRemoveDoneMsg{branch: branch, err: err}
+	}
+}
+
+func (m uiModel) doForceRemove(branch string) tea.Cmd {
+	return func() tea.Msg {
+		err := Remove(m.ctx, m.d, RemoveInput{Branch: branch, OutputDir: m.in.OutputDir, Force: true})
 		return uiRemoveDoneMsg{branch: branch, err: err}
 	}
 }
@@ -589,6 +611,7 @@ func uiRenderHelp() string {
 		"d           Diff selected worktree against base (default origin/main)\n" +
 		"y           Yank path of selected worktree (OSC-52)\n" +
 		"r           Remove selected worktree (with confirmation)\n" +
+		"R           Force-remove selected worktree (discards unmerged work, with confirmation)\n" +
 		"p           Prune merged worktrees (with confirmation)\n" +
 		"/           Filter / search worktrees\n" +
 		"?           Show this help\n" +
@@ -605,6 +628,9 @@ func uiRenderModal(m uiModel) string {
 	case uiModeConfirmRemove:
 		title = fmt.Sprintf("Remove worktree: %s", m.confirmBranch)
 		detail = "This will permanently delete the worktree and its branch."
+	case uiModeConfirmForceRemove:
+		title = fmt.Sprintf("Force-remove worktree: %s", m.confirmBranch)
+		detail = "This will force-delete the worktree and its branch, discarding uncommitted changes and unmerged commits."
 	case uiModeConfirmPrune:
 		title = "Prune merged worktrees"
 		detail = "All worktrees whose branches are merged into main will be removed."

--- a/internal/treepad/ui_test.go
+++ b/internal/treepad/ui_test.go
@@ -495,6 +495,59 @@ func TestUIDestructive(t *testing.T) {
 		}
 	})
 
+	t.Run("R enters confirmForceRemove mode with branch name", func(t *testing.T) {
+		m := uiModel{rows: rows2, cursor: 1}
+		updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'R'}})
+		m2 := updated.(uiModel)
+		if m2.mode != uiModeConfirmForceRemove {
+			t.Errorf("mode = %v, want uiModeConfirmForceRemove", m2.mode)
+		}
+		if m2.confirmBranch != "feat" {
+			t.Errorf("confirmBranch = %q, want %q", m2.confirmBranch, "feat")
+		}
+		if cmd != nil {
+			t.Error("R should not dispatch a command immediately")
+		}
+	})
+
+	t.Run("y in confirmForceRemove dispatches ForceRemove and returns to normal mode", func(t *testing.T) {
+		m := uiModel{
+			rows:          rows2,
+			cursor:        1,
+			mode:          uiModeConfirmForceRemove,
+			confirmBranch: "feat",
+		}
+		updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+		m2 := updated.(uiModel)
+		if m2.mode != uiModeNormal {
+			t.Errorf("mode = %v, want uiModeNormal after confirm", m2.mode)
+		}
+		if !m2.actionInFlight {
+			t.Error("actionInFlight should be true after y confirm")
+		}
+		if cmd == nil {
+			t.Error("expected dispatch command after y confirm")
+		}
+	})
+
+	t.Run("non-y key in confirmForceRemove cancels and returns to normal", func(t *testing.T) {
+		m := uiModel{
+			mode:          uiModeConfirmForceRemove,
+			confirmBranch: "feat",
+		}
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+		m2 := updated.(uiModel)
+		if m2.mode != uiModeNormal {
+			t.Errorf("mode = %v, want uiModeNormal after cancel", m2.mode)
+		}
+		if m2.confirmBranch != "" {
+			t.Errorf("confirmBranch = %q, want empty after cancel", m2.confirmBranch)
+		}
+		if m2.actionInFlight {
+			t.Error("actionInFlight should be false after cancel")
+		}
+	})
+
 	t.Run("p enters confirmPrune mode", func(t *testing.T) {
 		m := uiModel{rows: rows2}
 		updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
@@ -583,6 +636,16 @@ func TestUIDestructive(t *testing.T) {
 		for _, want := range []string{"feat/my-branch", "confirm", "cancel"} {
 			if !strings.Contains(view, want) {
 				t.Errorf("modal view missing %q", want)
+			}
+		}
+	})
+
+	t.Run("view renders force-remove modal with branch name and danger copy", func(t *testing.T) {
+		m := uiModel{mode: uiModeConfirmForceRemove, confirmBranch: "feat/my-branch"}
+		view := m.View()
+		for _, want := range []string{"feat/my-branch", "Force-remove", "confirm", "cancel"} {
+			if !strings.Contains(view, want) {
+				t.Errorf("force-remove modal view missing %q", want)
 			}
 		}
 	})


### PR DESCRIPTION
## Summary

- Adds `R` (shift-r) to the TUI fleet view as a force-remove shortcut, equivalent to `git worktree remove --force` + `git branch -D`
- Useful when a worktree has uncommitted changes or an unmerged branch that would cause the normal `r` remove to fail
- A confirmation modal (distinct copy from `r`) must be dismissed with `y` before anything is deleted

## Implementation

- `RemoveInput.Force bool` added to the existing `Remove` entry point — threads through to `removeWorktreeAndArtifact` which already supported force; no new exported function needed
- `uiModeConfirmForceRemove` state follows the same state-machine pattern as `uiModeConfirmRemove`; reuses `uiRemoveDoneMsg` so the success toast and refresh path are shared

## Tests

- Unit: three tests mirror the existing `r` suite (mode entry, confirm dispatch, cancel) plus a modal rendering test
- Unit: `Remove` with `Force: true` asserts `--force` and `-D` flags are issued to git
- E2e: `ui_script_remove` (baseline `r` happy path, previously missing), `ui_script_force_remove` (dirty worktree where CLI remove fails → TUI force-remove succeeds), `ui_script_force_remove_cancel` (cancel preserves worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)