### PR TITLE
fix(prune): don't remove fresh worktrees with no commits yet

### DIFF
--- a/internal/treepad/doctor_test.go
+++ b/internal/treepad/doctor_test.go
@@ -52,7 +52,8 @@ func TestDoctor(t *testing.T) {
 	t.Run("stale finding when last commit exceeds threshold", func(t *testing.T) {
 		runner := &seqRunner{responses: []runResponse{
 			{output: porcelain},                                // git worktree list
-			{output: []byte("")},                               // git branch --merged (nothing)
+			{output: []byte("aaa111\n")},                       // git rev-parse main^{commit}
+			{output: []byte("")},                               // git for-each-ref --merged (nothing)
 			{output: recentCommitOutput("abc1234", "init")},    // log: main (recent)
 			{output: []byte("")},                               // dirty: main (clean)
 			{output: staleCommitOutput("def5678", "old work")}, // log: feat (stale)
@@ -77,7 +78,8 @@ func TestDoctor(t *testing.T) {
 	t.Run("dirty-old finding supersedes stale when worktree is also dirty", func(t *testing.T) {
 		runner := &seqRunner{responses: []runResponse{
 			{output: porcelain},
-			{output: []byte("")},
+			{output: []byte("aaa111\n")}, // git rev-parse main^{commit}
+			{output: []byte("")},         // git for-each-ref --merged
 			{output: recentCommitOutput("abc1234", "init")},
 			{output: []byte("")},                               // dirty: main clean
 			{output: staleCommitOutput("def5678", "old work")}, // feat: stale
@@ -103,7 +105,8 @@ func TestDoctor(t *testing.T) {
 	t.Run("merged-present finding when worktree branch is in merged set", func(t *testing.T) {
 		runner := &seqRunner{responses: []runResponse{
 			{output: porcelain},
-			{output: []byte("feat\n")},                        // branch --merged: feat is merged
+			{output: []byte("aaa111\n")},                      // git rev-parse main^{commit}
+			{output: []byte("feat bbb222\n")},                 // for-each-ref --merged: feat is merged
 			{output: recentCommitOutput("abc1234", "init")},   // log: main
 			{output: []byte("")},                              // dirty: main
 			{output: recentCommitOutput("def5678", "feat x")}, // log: feat
@@ -128,7 +131,8 @@ func TestDoctor(t *testing.T) {
 	t.Run("remote-gone finding when upstream configured but branch absent on remote", func(t *testing.T) {
 		runner := &seqRunner{responses: []runResponse{
 			{output: porcelain},
-			{output: []byte("")},                              // branch --merged: none
+			{output: []byte("aaa111\n")},                      // git rev-parse main^{commit}
+			{output: []byte("")},                              // for-each-ref --merged: none
 			{output: recentCommitOutput("abc1234", "init")},   // log: main
 			{output: []byte("")},                              // dirty: main
 			{err: errors.New("no upstream")},                  // rev-parse @{upstream}: main (none)
@@ -154,7 +158,8 @@ func TestDoctor(t *testing.T) {
 	t.Run("offline flag skips remote-gone check", func(t *testing.T) {
 		runner := &seqRunner{responses: []runResponse{
 			{output: porcelain},
-			{output: []byte("")},
+			{output: []byte("aaa111\n")}, // git rev-parse main^{commit}
+			{output: []byte("")},         // git for-each-ref --merged
 			{output: recentCommitOutput("abc1234", "init")},
 			{output: []byte("")},
 			{output: recentCommitOutput("def5678", "feat x")},
@@ -166,16 +171,17 @@ func TestDoctor(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		// All 6 calls consumed; any 7th would trip seqRunner's out-of-bounds guard.
-		if runner.idx != 6 {
-			t.Errorf("runner called %d times, want 6 (rev-parse/ls-remote must be skipped)", runner.idx)
+		// All 7 calls consumed; any 8th would trip seqRunner's out-of-bounds guard.
+		if runner.idx != 7 {
+			t.Errorf("runner called %d times, want 7 (rev-parse/ls-remote must be skipped)", runner.idx)
 		}
 	})
 
 	t.Run("artifact-missing finding when expected file is absent", func(t *testing.T) {
 		runner := &seqRunner{responses: []runResponse{
 			{output: porcelain},
-			{output: []byte("")},
+			{output: []byte("aaa111\n")}, // git rev-parse main^{commit}
+			{output: []byte("")},         // git for-each-ref --merged
 			{output: recentCommitOutput("abc1234", "init")},
 			{output: []byte("")},
 			{output: recentCommitOutput("def5678", "feat x")},
@@ -208,7 +214,8 @@ func TestDoctor(t *testing.T) {
 
 		runner := &seqRunner{responses: []runResponse{
 			{output: porcelain},
-			{output: []byte("")},
+			{output: []byte("aaa111\n")}, // git rev-parse main^{commit}
+			{output: []byte("")},         // git for-each-ref --merged
 			{output: recentCommitOutput("abc1234", "init")},
 			{output: []byte("")},
 			{output: recentCommitOutput("def5678", "feat x")},
@@ -239,7 +246,8 @@ func TestDoctor(t *testing.T) {
 
 		runner := &seqRunner{responses: []runResponse{
 			{output: porcelain},
-			{output: []byte("")},
+			{output: []byte("aaa111\n")}, // git rev-parse main^{commit}
+			{output: []byte("")},         // git for-each-ref --merged
 			{output: recentCommitOutput("abc1234", "init")},
 			{output: []byte("")},
 			{output: recentCommitOutput("def5678", "feat x")},
@@ -262,7 +270,8 @@ func TestDoctor(t *testing.T) {
 	t.Run("json flag emits JSON array", func(t *testing.T) {
 		runner := &seqRunner{responses: []runResponse{
 			{output: porcelain},
-			{output: []byte("feat\n")}, // merged
+			{output: []byte("aaa111\n")},      // git rev-parse main^{commit}
+			{output: []byte("feat bbb222\n")}, // for-each-ref --merged: feat merged
 			{output: recentCommitOutput("abc1234", "init")},
 			{output: []byte("")},
 			{output: recentCommitOutput("def5678", "feat x")},
@@ -291,7 +300,8 @@ func TestDoctor(t *testing.T) {
 	t.Run("strict returns error when findings exist", func(t *testing.T) {
 		runner := &seqRunner{responses: []runResponse{
 			{output: porcelain},
-			{output: []byte("feat\n")}, // merged → finding
+			{output: []byte("aaa111\n")},      // git rev-parse main^{commit}
+			{output: []byte("feat bbb222\n")}, // for-each-ref --merged: feat merged → finding
 			{output: recentCommitOutput("abc1234", "init")},
 			{output: []byte("")},
 			{output: recentCommitOutput("def5678", "feat x")},
@@ -318,7 +328,8 @@ func TestDoctor(t *testing.T) {
 
 		runner := &seqRunner{responses: []runResponse{
 			{output: porcelain},
-			{output: []byte("")},
+			{output: []byte("aaa111\n")}, // git rev-parse main^{commit}
+			{output: []byte("")},         // git for-each-ref --merged
 			{output: recentCommitOutput("abc1234", "init")},
 			{output: []byte("")},
 			{output: recentCommitOutput("def5678", "feat x")},
@@ -339,7 +350,8 @@ func TestDoctor(t *testing.T) {
 		detachedPorcelain := []byte("worktree " + mainPath + "\nHEAD abc123\ndetached\n\n")
 		runner := &seqRunner{responses: []runResponse{
 			{output: detachedPorcelain},
-			{output: []byte("")}, // branch --merged
+			{output: []byte("aaa111\n")}, // git rev-parse main^{commit}
+			{output: []byte("")},         // git for-each-ref --merged
 			// no per-worktree calls because detached is skipped
 		}}
 		d := testDeps(runner, &fakeSyncer{}, &fakeOpener{})
@@ -348,8 +360,8 @@ func TestDoctor(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if runner.idx != 2 {
-			t.Errorf("runner called %d times, want 2 (no per-wt calls for detached)", runner.idx)
+		if runner.idx != 3 {
+			t.Errorf("runner called %d times, want 3 (no per-wt calls for detached)", runner.idx)
 		}
 	})
 
@@ -366,12 +378,21 @@ func TestDoctor(t *testing.T) {
 			wantErr: "git not found",
 		},
 		{
-			name: "git branch --merged fails",
+			name: "git rev-parse base fails",
 			runner: &seqRunner{responses: []runResponse{
 				{output: porcelain},
 				{err: errors.New("unknown revision")},
 			}},
 			wantErr: "unknown revision",
+		},
+		{
+			name: "git for-each-ref --merged fails",
+			runner: &seqRunner{responses: []runResponse{
+				{output: porcelain},
+				{output: []byte("aaa111\n")},
+				{err: errors.New("for-each-ref failed")},
+			}},
+			wantErr: "for-each-ref failed",
 		},
 		{
 			name: "last commit probe fails",

--- a/internal/treepad/prune.go
+++ b/internal/treepad/prune.go
@@ -61,6 +61,8 @@ func gatherMerged(ctx context.Context, d Deps, rc repoContext, cwd, base string)
 		return pruneSelection{}, err
 	}
 
+	d.Log.Debug("base=%s merged=%v", base, merged)
+
 	mergedSet := make(map[string]bool, len(merged))
 	for _, b := range merged {
 		mergedSet[b] = true
@@ -68,10 +70,13 @@ func gatherMerged(ctx context.Context, d Deps, rc repoContext, cwd, base string)
 
 	var candidates []worktree.Worktree
 	for _, wt := range rc.Worktrees {
+		d.Log.Debug("worktree branch=%q isMain=%v prunable=%v", wt.Branch, wt.IsMain, wt.Prunable)
 		if wt.IsMain || wt.Branch == rc.Main.Branch || wt.Branch == "(detached)" || wt.Prunable {
+			d.Log.Debug("  skip: main/detached/prunable")
 			continue
 		}
 		if !mergedSet[wt.Branch] {
+			d.Log.Debug("  skip: not merged into %s", base)
 			continue
 		}
 		if rel, relErr := filepath.Rel(wt.Path, cwd); relErr == nil && !strings.HasPrefix(rel, "..") {
@@ -97,8 +102,17 @@ func gatherMerged(ctx context.Context, d Deps, rc repoContext, cwd, base string)
 			continue
 		}
 
+		d.Log.Debug("  candidate: %s", wt.Branch)
 		candidates = append(candidates, wt)
 	}
+
+	d.Log.Debug("candidates=%v", func() []string {
+		names := make([]string, len(candidates))
+		for i, c := range candidates {
+			names[i] = c.Branch
+		}
+		return names
+	}())
 
 	return pruneSelection{
 		candidates: candidates,

--- a/internal/treepad/prune_test.go
+++ b/internal/treepad/prune_test.go
@@ -27,10 +27,11 @@ func TestPrune(t *testing.T) {
 
 	t.Run("dry-run lists candidates without removing", func(t *testing.T) {
 		runner := &seqRunner{responses: []runResponse{
-			{output: twoPorcelain},           // git worktree list
-			{output: []byte("feat\n")},       // git branch --merged
-			{output: []byte("")},             // dirty: feat (clean)
-			{err: errors.New("no upstream")}, // rev-parse @{upstream}: feat (no upstream)
+			{output: twoPorcelain},            // git worktree list
+			{output: []byte("aaa111\n")},      // git rev-parse main^{commit}
+			{output: []byte("feat bbb222\n")}, // git for-each-ref --merged
+			{output: []byte("")},              // dirty: feat (clean)
+			{err: errors.New("no upstream")},  // rev-parse @{upstream}: feat (no upstream)
 		}}
 		deps := testDeps(runner, &fakeSyncer{}, &fakeOpener{})
 
@@ -38,8 +39,8 @@ func TestPrune(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if runner.idx != 4 {
-			t.Errorf("runner called %d times, want 4 (no removes in dry-run)", runner.idx)
+		if runner.idx != 5 {
+			t.Errorf("runner called %d times, want 5 (no removes in dry-run)", runner.idx)
 		}
 	})
 
@@ -50,13 +51,14 @@ func TestPrune(t *testing.T) {
 		}
 
 		runner := &seqRunner{responses: []runResponse{
-			{output: twoPorcelain},           // git worktree list
-			{output: []byte("feat\n")},       // git branch --merged
-			{output: []byte("")},             // dirty: feat (clean)
-			{err: errors.New("no upstream")}, // rev-parse @{upstream}: feat
-			{},                               // git worktree remove
-			{},                               // git branch -d
-			{},                               // git worktree prune
+			{output: twoPorcelain},            // git worktree list
+			{output: []byte("aaa111\n")},      // git rev-parse main^{commit}
+			{output: []byte("feat bbb222\n")}, // git for-each-ref --merged
+			{output: []byte("")},              // dirty: feat (clean)
+			{err: errors.New("no upstream")},  // rev-parse @{upstream}: feat
+			{},                                // git worktree remove
+			{},                                // git branch -d
+			{},                                // git worktree prune
 		}}
 		deps := testDeps(runner, &fakeSyncer{}, &fakeOpener{})
 
@@ -64,8 +66,8 @@ func TestPrune(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if runner.idx != 7 {
-			t.Errorf("runner called %d times, want 7", runner.idx)
+		if runner.idx != 8 {
+			t.Errorf("runner called %d times, want 8", runner.idx)
 		}
 		if _, statErr := os.Stat(wsFile); !os.IsNotExist(statErr) {
 			t.Error("artifact file should have been deleted")
@@ -75,8 +77,9 @@ func TestPrune(t *testing.T) {
 	t.Run("skips unmerged worktrees", func(t *testing.T) {
 		runner := &seqRunner{responses: []runResponse{
 			{output: twoPorcelain},
-			{output: []byte("")}, // nothing merged
-			{},                   // git worktree prune
+			{output: []byte("aaa111\n")}, // git rev-parse main^{commit}
+			{output: []byte("")},         // git for-each-ref --merged (empty)
+			{},                           // git worktree prune
 		}}
 		deps := testDeps(runner, &fakeSyncer{}, &fakeOpener{})
 
@@ -84,20 +87,39 @@ func TestPrune(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if runner.idx != 3 {
-			t.Errorf("runner called %d times, want 3", runner.idx)
+		if runner.idx != 4 {
+			t.Errorf("runner called %d times, want 4", runner.idx)
+		}
+	})
+
+	t.Run("skips fresh worktree whose tip equals base tip", func(t *testing.T) {
+		runner := &seqRunner{responses: []runResponse{
+			{output: twoPorcelain},
+			{output: []byte("aaa111\n")},      // git rev-parse main^{commit}
+			{output: []byte("feat aaa111\n")}, // feat tip == main tip; filtered out
+			{},                                // git worktree prune
+		}}
+		deps := testDeps(runner, &fakeSyncer{}, &fakeOpener{})
+
+		err := Prune(context.Background(), deps, PruneInput{Base: "main", OutputDir: outputDir, Yes: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if runner.idx != 4 {
+			t.Errorf("runner called %d times, want 4 (fresh branch kept)", runner.idx)
 		}
 	})
 
 	t.Run("skips target when cwd is inside it, continues others", func(t *testing.T) {
 		runner := &seqRunner{responses: []runResponse{
 			{output: threePorcelain},
-			{output: []byte("feat\nother\n")}, // both merged
-			{output: []byte("")},              // dirty: other (clean)
-			{err: errors.New("no upstream")},  // rev-parse @{upstream}: other
-			{},                                // git worktree remove (other)
-			{},                                // git branch -d (other)
-			{},                                // git worktree prune
+			{output: []byte("aaa111\n")},                    // git rev-parse main^{commit}
+			{output: []byte("feat bbb222\nother ccc333\n")}, // both merged
+			{output: []byte("")},                            // dirty: other (clean)
+			{err: errors.New("no upstream")},                // rev-parse @{upstream}: other
+			{},                                              // git worktree remove (other)
+			{},                                              // git branch -d (other)
+			{},                                              // git worktree prune
 		}}
 		deps := testDeps(runner, &fakeSyncer{}, &fakeOpener{})
 
@@ -111,23 +133,24 @@ func TestPrune(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if runner.idx != 7 {
-			t.Errorf("runner called %d times, want 7 (skip feat, remove other)", runner.idx)
+		if runner.idx != 8 {
+			t.Errorf("runner called %d times, want 8 (skip feat, remove other)", runner.idx)
 		}
 	})
 
 	t.Run("per-target failure does not stop remaining removals", func(t *testing.T) {
 		runner := &seqRunner{responses: []runResponse{
 			{output: threePorcelain},
-			{output: []byte("feat\nother\n")},
-			{output: []byte("")},                 // dirty: feat (clean)
-			{err: errors.New("no upstream")},     // rev-parse @{upstream}: feat
-			{output: []byte("")},                 // dirty: other (clean)
-			{err: errors.New("no upstream")},     // rev-parse @{upstream}: other
-			{err: errors.New("locked worktree")}, // git worktree remove feat fails
-			{},                                   // git worktree remove other
-			{},                                   // git branch -d other
-			{},                                   // git worktree prune
+			{output: []byte("aaa111\n")},                    // git rev-parse main^{commit}
+			{output: []byte("feat bbb222\nother ccc333\n")}, // git for-each-ref --merged
+			{output: []byte("")},                            // dirty: feat (clean)
+			{err: errors.New("no upstream")},                // rev-parse @{upstream}: feat
+			{output: []byte("")},                            // dirty: other (clean)
+			{err: errors.New("no upstream")},                // rev-parse @{upstream}: other
+			{err: errors.New("locked worktree")},            // git worktree remove feat fails
+			{},                                              // git worktree remove other
+			{},                                              // git branch -d other
+			{},                                              // git worktree prune
 		}}
 		deps := testDeps(runner, &fakeSyncer{}, &fakeOpener{})
 
@@ -138,8 +161,8 @@ func TestPrune(t *testing.T) {
 		if !strings.Contains(err.Error(), "feat") {
 			t.Errorf("error %q should mention failed branch", err)
 		}
-		if runner.idx != 10 {
-			t.Errorf("runner called %d times, want 10", runner.idx)
+		if runner.idx != 11 {
+			t.Errorf("runner called %d times, want 11", runner.idx)
 		}
 	})
 
@@ -156,12 +179,21 @@ func TestPrune(t *testing.T) {
 			wantErr: "git not found",
 		},
 		{
-			name: "git branch --merged fails",
+			name: "git rev-parse base fails",
 			runner: &seqRunner{responses: []runResponse{
 				{output: twoPorcelain},
-				{err: errors.New("unknown branch")},
+				{err: errors.New("unknown revision")},
 			}},
-			wantErr: "unknown branch",
+			wantErr: "unknown revision",
+		},
+		{
+			name: "git for-each-ref --merged fails",
+			runner: &seqRunner{responses: []runResponse{
+				{output: twoPorcelain},
+				{output: []byte("aaa111\n")},
+				{err: errors.New("for-each-ref failed")},
+			}},
+			wantErr: "for-each-ref failed",
 		},
 	}
 	for _, tt := range errorTests {
@@ -365,7 +397,8 @@ func TestPrune(t *testing.T) {
 
 		runner := &seqRunner{responses: []runResponse{
 			{output: porcelainWithPrunable}, // git worktree list (main + prunable stale-branch)
-			{output: []byte("")},            // git branch --merged (nothing merged)
+			{output: []byte("aaa111\n")},    // git rev-parse main^{commit}
+			{output: []byte("")},            // git for-each-ref --merged (nothing merged)
 			{},                              // git worktree prune (cleans stale metadata)
 		}}
 		deps := testDeps(runner, &fakeSyncer{}, &fakeOpener{})
@@ -374,8 +407,8 @@ func TestPrune(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if runner.idx != 3 {
-			t.Errorf("runner called %d times, want 3", runner.idx)
+		if runner.idx != 4 {
+			t.Errorf("runner called %d times, want 4", runner.idx)
 		}
 	})
 
@@ -383,9 +416,10 @@ func TestPrune(t *testing.T) {
 		var buf strings.Builder
 		runner := &seqRunner{responses: []runResponse{
 			{output: twoPorcelain},
-			{output: []byte("feat\n")},
-			{output: []byte("")},             // dirty: feat (clean)
-			{err: errors.New("no upstream")}, // rev-parse @{upstream}: feat
+			{output: []byte("aaa111\n")},      // git rev-parse main^{commit}
+			{output: []byte("feat bbb222\n")}, // git for-each-ref --merged
+			{output: []byte("")},              // dirty: feat (clean)
+			{err: errors.New("no upstream")},  // rev-parse @{upstream}: feat
 		}}
 		deps := Deps{
 			Runner: runner,
@@ -403,8 +437,8 @@ func TestPrune(t *testing.T) {
 		if !strings.Contains(buf.String(), "git worktree prune") {
 			t.Errorf("dry-run output should mention 'git worktree prune'; got:\n%s", buf.String())
 		}
-		if runner.idx != 4 {
-			t.Errorf("runner called %d times in dry-run, want 4", runner.idx)
+		if runner.idx != 5 {
+			t.Errorf("runner called %d times in dry-run, want 5", runner.idx)
 		}
 	})
 
@@ -412,9 +446,10 @@ func TestPrune(t *testing.T) {
 		var buf strings.Builder
 		runner := &seqRunner{responses: []runResponse{
 			{output: twoPorcelain},
-			{output: []byte("feat\n")},   // git branch --merged
-			{output: []byte("M f.go\n")}, // dirty: feat (dirty)
-			{},                           // git worktree prune (no candidates remain)
+			{output: []byte("aaa111\n")},      // git rev-parse main^{commit}
+			{output: []byte("feat bbb222\n")}, // git for-each-ref --merged
+			{output: []byte("M f.go\n")},      // dirty: feat (dirty)
+			{},                                // git worktree prune (no candidates remain)
 		}}
 		deps := Deps{
 			Runner: runner,
@@ -432,8 +467,8 @@ func TestPrune(t *testing.T) {
 		if !strings.Contains(buf.String(), "skipping feat") || !strings.Contains(buf.String(), "uncommitted") {
 			t.Errorf("expected skip warning for dirty worktree; got:\n%s", buf.String())
 		}
-		if runner.idx != 4 {
-			t.Errorf("runner called %d times, want 4 (list, merged, dirty, prune)", runner.idx)
+		if runner.idx != 5 {
+			t.Errorf("runner called %d times, want 5 (list, rev-parse, for-each-ref, dirty, prune)", runner.idx)
 		}
 	})
 
@@ -441,7 +476,8 @@ func TestPrune(t *testing.T) {
 		var buf strings.Builder
 		runner := &seqRunner{responses: []runResponse{
 			{output: twoPorcelain},
-			{output: []byte("feat\n")},        // git branch --merged
+			{output: []byte("aaa111\n")},      // git rev-parse main^{commit}
+			{output: []byte("feat bbb222\n")}, // git for-each-ref --merged
 			{output: []byte("")},              // dirty: feat (clean)
 			{output: []byte("origin/feat\n")}, // rev-parse @{upstream}: has upstream
 			{output: []byte("2\t0\n")},        // rev-list: 2 ahead, 0 behind
@@ -463,8 +499,8 @@ func TestPrune(t *testing.T) {
 		if !strings.Contains(buf.String(), "skipping feat") || !strings.Contains(buf.String(), "unpushed") {
 			t.Errorf("expected skip warning for unpushed commits; got:\n%s", buf.String())
 		}
-		if runner.idx != 6 {
-			t.Errorf("runner called %d times, want 6", runner.idx)
+		if runner.idx != 7 {
+			t.Errorf("runner called %d times, want 7", runner.idx)
 		}
 	})
 
@@ -472,9 +508,10 @@ func TestPrune(t *testing.T) {
 		var buf strings.Builder
 		runner := &seqRunner{responses: []runResponse{
 			{output: twoPorcelain},
-			{output: []byte("feat\n")},
-			{output: []byte("")},             // dirty: feat (clean)
-			{err: errors.New("no upstream")}, // rev-parse: feat (no upstream)
+			{output: []byte("aaa111\n")},      // git rev-parse main^{commit}
+			{output: []byte("feat bbb222\n")}, // git for-each-ref --merged
+			{output: []byte("")},              // dirty: feat (clean)
+			{err: errors.New("no upstream")},  // rev-parse: feat (no upstream)
 		}}
 		deps := Deps{
 			Runner: runner,
@@ -493,8 +530,8 @@ func TestPrune(t *testing.T) {
 			t.Errorf("expected 'aborted' in output; got:\n%s", buf.String())
 		}
 		// Must not reach removal or prune step.
-		if runner.idx != 4 {
-			t.Errorf("runner called %d times after abort, want 4", runner.idx)
+		if runner.idx != 5 {
+			t.Errorf("runner called %d times after abort, want 5", runner.idx)
 		}
 	})
 
@@ -502,12 +539,13 @@ func TestPrune(t *testing.T) {
 		var buf strings.Builder
 		runner := &seqRunner{responses: []runResponse{
 			{output: twoPorcelain},
-			{output: []byte("feat\n")},
-			{output: []byte("")},             // dirty: feat (clean)
-			{err: errors.New("no upstream")}, // rev-parse
-			{},                               // git worktree remove
-			{},                               // git branch -d
-			{},                               // git worktree prune
+			{output: []byte("aaa111\n")},      // git rev-parse main^{commit}
+			{output: []byte("feat bbb222\n")}, // git for-each-ref --merged
+			{output: []byte("")},              // dirty: feat (clean)
+			{err: errors.New("no upstream")},  // rev-parse
+			{},                                // git worktree remove
+			{},                                // git branch -d
+			{},                                // git worktree prune
 		}}
 		deps := Deps{
 			Runner: runner,
@@ -522,8 +560,8 @@ func TestPrune(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if runner.idx != 7 {
-			t.Errorf("runner called %d times, want 7", runner.idx)
+		if runner.idx != 8 {
+			t.Errorf("runner called %d times, want 8", runner.idx)
 		}
 	})
 }

--- a/internal/ui/printer.go
+++ b/internal/ui/printer.go
@@ -12,17 +12,20 @@ package ui
 import (
 	"fmt"
 	"io"
+	"os"
 )
 
 // Printer writes fixed-width tagged lines to an io.Writer.
 // A nil Printer is safe to use; all calls are no-ops.
 type Printer struct {
-	w io.Writer
+	w     io.Writer
+	debug bool
 }
 
 // New returns a Printer that writes to w.
+// Debug output is enabled when TREEPAD_DEBUG is set to a non-empty value.
 func New(w io.Writer) *Printer {
-	return &Printer{w: w}
+	return &Printer{w: w, debug: os.Getenv("TREEPAD_DEBUG") != ""}
 }
 
 // Step emits a [STEP] line for an action in progress.
@@ -39,6 +42,14 @@ func (p *Printer) Warn(format string, a ...any) { p.write("[WARN] ", format, a..
 
 // Err emits an [ERR]  line for fatal errors presented to the user.
 func (p *Printer) Err(format string, a ...any) { p.write("[ERR]  ", format, a...) }
+
+// Debug emits a [DEBG] line, but only when TREEPAD_DEBUG is set.
+func (p *Printer) Debug(format string, a ...any) {
+	if p == nil || !p.debug {
+		return
+	}
+	p.write("[DEBG] ", format, a...)
+}
 
 // Prompt writes a bare prompt string to stderr without a trailing newline or tag.
 // Used for interactive confirmation prompts where a tag would look odd.

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -114,19 +114,36 @@ func parsePorcelain(data []byte) ([]Worktree, error) {
 	return worktrees, nil
 }
 
-// MergedBranches returns local branches already merged into base, excluding base itself.
+// MergedBranches returns local branches already merged into base. It excludes
+// base itself and any branch whose tip points at exactly the same commit as
+// base — such branches have no unique history yet (freshly created, or fast-
+// forwarded with no subsequent activity) and are not safe to auto-prune, since
+// a fresh worktree's work-in-progress has no commits to mark it distinct.
 func MergedBranches(ctx context.Context, runner CommandRunner, base string) ([]string, error) {
-	out, err := runner.Run(ctx, "git", "branch", "--merged", base, "--format=%(refname:short)")
+	baseOut, err := runner.Run(ctx, "git", "rev-parse", base+"^{commit}")
 	if err != nil {
-		return nil, fmt.Errorf("git branch --merged: %w", err)
+		return nil, fmt.Errorf("git rev-parse %s: %w", base, err)
+	}
+	baseSHA := strings.TrimSpace(string(baseOut))
+
+	out, err := runner.Run(ctx, "git", "for-each-ref",
+		"--merged="+base,
+		"--format=%(refname:short) %(objectname)",
+		"refs/heads/")
+	if err != nil {
+		return nil, fmt.Errorf("git for-each-ref --merged: %w", err)
 	}
 	var branches []string
 	for line := range strings.SplitSeq(string(out), "\n") {
 		line = strings.TrimSpace(line)
-		if line == "" || line == base {
+		if line == "" {
 			continue
 		}
-		branches = append(branches, line)
+		name, sha, ok := strings.Cut(line, " ")
+		if !ok || name == base || sha == baseSHA {
+			continue
+		}
+		branches = append(branches, name)
 	}
 	return branches, nil
 }

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -155,38 +155,87 @@ func TestParsePorcelain_doesNotSetIsMain(t *testing.T) {
 	}
 }
 
+type seqFakeRunner struct {
+	responses []fakeResponse
+	idx       int
+}
+
+type fakeResponse struct {
+	output []byte
+	err    error
+}
+
+func (s *seqFakeRunner) Run(_ context.Context, _ string, _ ...string) ([]byte, error) {
+	if s.idx >= len(s.responses) {
+		return nil, errors.New("unexpected runner call")
+	}
+	r := s.responses[s.idx]
+	s.idx++
+	return r.output, r.err
+}
+
 func TestMergedBranches(t *testing.T) {
 	ctx := context.Background()
 
+	const baseSHA = "aaa111\n"
+
 	tests := []struct {
-		name    string
-		output  []byte
-		err     error
-		base    string
-		want    []string
-		wantErr bool
+		name      string
+		responses []fakeResponse
+		base      string
+		want      []string
+		wantErr   bool
 	}{
 		{
-			name:   "returns merged branches excluding base",
-			output: []byte("main\nfeat\nfix/bug\n"),
-			base:   "main",
-			want:   []string{"feat", "fix/bug"},
+			name: "returns merged branches excluding base and fresh tips",
+			responses: []fakeResponse{
+				{output: []byte(baseSHA)},
+				{output: []byte("main aaa111\nfeat bbb222\nfix/bug ccc333\n")},
+			},
+			base: "main",
+			want: []string{"feat", "fix/bug"},
 		},
 		{
-			name:   "blank lines ignored",
-			output: []byte("\nfeat\n\n"),
-			base:   "main",
-			want:   []string{"feat"},
+			name: "excludes branches whose tip equals base tip (fresh worktrees)",
+			responses: []fakeResponse{
+				{output: []byte(baseSHA)},
+				{output: []byte("fresh aaa111\nreal bbb222\n")},
+			},
+			base: "main",
+			want: []string{"real"},
 		},
 		{
-			name:   "nothing merged besides base",
-			output: []byte("main\n"),
-			base:   "main",
-			want:   nil,
+			name: "blank lines ignored",
+			responses: []fakeResponse{
+				{output: []byte(baseSHA)},
+				{output: []byte("\nfeat bbb222\n\n")},
+			},
+			base: "main",
+			want: []string{"feat"},
 		},
 		{
-			name:    "runner error",
-			err:     errors.New("git not found"),
+			name: "nothing merged besides base",
+			responses: []fakeResponse{
+				{output: []byte(baseSHA)},
+				{output: []byte("main aaa111\n")},
+			},
+			base: "main",
+			want: nil,
+		},
+		{
+			name: "rev-parse error",
+			responses: []fakeResponse{
+				{err: errors.New("unknown revision")},
+			},
+			base:    "main",
+			wantErr: true,
+		},
+		{
+			name: "for-each-ref error",
+			responses: []fakeResponse{
+				{output: []byte(baseSHA)},
+				{err: errors.New("git for-each-ref failed")},
+			},
 			base:    "main",
 			wantErr: true,
 		},
@@ -194,7 +243,7 @@ func TestMergedBranches(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := MergedBranches(ctx, fakeRunner{output: tt.output, err: tt.err}, tt.base)
+			got, err := MergedBranches(ctx, &seqFakeRunner{responses: tt.responses}, tt.base)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")


### PR DESCRIPTION
## Summary

- `git branch --merged <base>` trivially includes branches created from base with no commits, because their tip is identical to base's tip. `tp prune` was using this list directly, causing active but uncommitted worktrees to be removed.
- `MergedBranches` now fetches each merged branch's tip SHA via `git for-each-ref --merged` and excludes any branch whose SHA equals base's tip SHA — these have no unique history and are not safe to auto-prune.
- Adds `TREEPAD_DEBUG=1` env-var gate and debug logging in `gatherMerged` to surface the merged set and per-worktree skip decisions for future diagnosis.

## Test plan

- [ ] `go test ./internal/...` — 433 tests pass, including new `"skips fresh worktree whose tip equals base tip"` case
- [ ] In a real repo, create a fresh worktree (`tp new <branch>`), don't commit anything, run `tp prune` — confirm the fresh worktree is not listed as a removal candidate
- [ ] Run `TREEPAD_DEBUG=1 tp prune -n` and confirm `[DEBG]` lines show the merged set and skip decisions
- [ ] Run `tp prune` against a worktree whose branch genuinely has commits merged into main — confirm it is still removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)