### PR TITLE
feat(tui): number keys 0–9 jump to row N

### DIFF
--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -221,6 +221,7 @@ Business logic entry points. Each public function is a standalone top-level func
 - `collectStatusRows(ctx, deps.Deps, repo.Context, config.ArtifactConfig)` — probes each worktree
   - Queries `worktree.Dirty()`, `worktree.AheadBehind()`, `worktree.LastCommit()`; resolves artifact mtime
   - Skips git queries for prunable worktrees
+  - Applies `sort.SliceStable` to pin the `IsMain` row first, guaranteeing row 0 = main worktree regardless of git's output order
 
 ### `tui.go` / `tui_update.go` / `tui_view.go`
 
@@ -228,7 +229,7 @@ Business logic entry points. Each public function is a standalone top-level func
   - Returns `ErrNotTTY` (exit code 2) if stdout is not a terminal
   - Enters alt-screen; auto-refreshes every 2 seconds
   - `uiMode` constants: `uiModeNormal`, `uiModeConfirmRemove`, `uiModeConfirmForceRemove`, `uiModeConfirmPrune`, `uiModeConfirmShell`, `uiModeHelp`, `uiModeFilter`
-  - Key events: `s`/`S` sync, `r`/`R` remove (confirm → `y`), `p` prune (confirm → `y`), `o` open, `d` diff, `e` shell (confirm → `y` → `doShell()`: spawns `$SHELL` or `/bin/sh` in worktree dir via `tea.ExecProcess`; TUI suspends, resumes on shell exit), `y` yank (OSC-52), `/` enter filter mode (fuzzy match on branch or path basename), `Esc` clear filter, `?` help overlay, `Enter` cd+quit
+  - Key events: `0`–`9` jump cursor to row N (out-of-range shows a transient toast that re-arms its 2-second timer on each repeat press; implemented via `toastGen int` generation counter on `uiToastExpiredMsg` so stale ticks are ignored), `s`/`S` sync, `r`/`R` remove (confirm → `y`), `p` prune (confirm → `y`), `o` open, `d` diff, `e` shell (confirm → `y` → `doShell()`: spawns `$SHELL` or `/bin/sh` in worktree dir via `tea.ExecProcess`; TUI suspends, resumes on shell exit), `y` yank (OSC-52), `/` enter filter mode (fuzzy match on branch or path basename), `Esc` clear filter, `?` help overlay, `Enter` cd+quit
   - Filter mode (`uiModeFilter`) intercepts all keystrokes; Enter commits filter, Esc cancels
   - `selectedPath` set on Enter → after `p.Run()`, calls `uiEmitCD()` → `cd.EmitCD()` sentinel
 
@@ -595,6 +596,7 @@ tp [--verbose] <command>
    - `Init()` dispatches `doRefresh()` and `doTick()` (2-second tick)
    - `doRefresh()` calls `refreshStatus()` asynchronously; result arrives as `uiRefreshMsg`
    - Tick fires every 2s; skipped if an action is in flight
+   - `0`–`9` keys jump cursor to that row index (rows are rendered with inline number prefixes `0 `–`9 `); out-of-range shows a transient toast
    - `/` key enters `uiModeFilter`; keystrokes update `filterStr`; Enter commits, Esc cancels; committed filter applied via `filterRows()` (fuzzy match)
    - `e` key enters `uiModeConfirmShell`; `y` confirms → `doShell()`: `tea.ExecProcess($SHELL)` in worktree dir; TUI suspends, resumes on shell exit
    - Key events dispatch sync, remove, prune, open, diff, shell as async `tea.Cmd`s
@@ -626,7 +628,7 @@ tp [--verbose] <command>
 
 ---
 
-**Last Updated:** April 26, 2026
+**Last Updated:** April 27, 2026
 
 **Recent Changes:**
 - `internal/treepad/` monolith refactored into focused sub-packages: `lifecycle/`, `cd/`, `cdshell/`, `fromspec/`, `deps/`, `repo/`, `cwd/`
@@ -641,3 +643,4 @@ tp [--verbose] <command>
 - Added `internal/profile/` package: `Profiler` interface, `Recorder` (production), `Disabled()` (no-op)
 - TUI `e` key: enters `uiModeConfirmShell`; confirmed → `tea.ExecProcess($SHELL)` in selected worktree; TUI suspends then resumes
 - TUI auto-refresh interval is 2 seconds (not 5)
+- TUI `0`–`9` keys: jump cursor directly to row N; `collectStatusRows` stable-sorts main worktree first so row 0 is always the base; out-of-range toast re-arms its 2-second timer on each repeat press via `toastGen` generation counter

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -669,6 +669,7 @@ Renders a full-screen alt-screen display that auto-refreshes every 5 seconds. Sh
 
 | Key            | Action                                                                                                        |
 | -------------- | ------------------------------------------------------------------------------------------------------------- |
+| `0`–`9`        | Jump cursor to row N (row 0 is always the main worktree); shows an out-of-range notice if N ≥ number of rows |
 | `↑` / `k`      | Move cursor up                                                                                                |
 | `↓` / `j`      | Move cursor down                                                                                              |
 | `Enter`        | Exit and cd into selected worktree                                                                            |

--- a/internal/treepad/status.go
+++ b/internal/treepad/status.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"sort"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -107,6 +108,7 @@ func collectStatusRows(
 
 		rows = append(rows, row)
 	}
+	sort.SliceStable(rows, func(i, j int) bool { return rows[i].IsMain && !rows[j].IsMain })
 	return rows, nil
 }
 

--- a/internal/treepad/status_test.go
+++ b/internal/treepad/status_test.go
@@ -11,8 +11,10 @@ import (
 	"testing"
 	"time"
 
+	"treepad/internal/config"
 	"treepad/internal/slug"
 	"treepad/internal/treepad/deps"
+	"treepad/internal/treepad/repo"
 	"treepad/internal/treepad/treepadtest"
 	"treepad/internal/worktree"
 )
@@ -442,4 +444,25 @@ func TestUiBuildSummary(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestCollectStatusRowsMainFirst(t *testing.T) {
+	// Git may list worktrees in any order. collectStatusRows must pin IsMain first.
+	rc := repo.Context{
+		Worktrees: []worktree.Worktree{
+			{Branch: "feat", Path: "/repo/feat", Prunable: true, PrunableReason: "gone"},
+			{Branch: "main", Path: "/repo/main", IsMain: true, Prunable: true, PrunableReason: "gone"},
+		},
+		Main: worktree.Worktree{Branch: "main", Path: "/repo/main", IsMain: true},
+	}
+	rows, err := collectStatusRows(context.Background(), deps.Deps{}, rc, config.ArtifactConfig{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+	if !rows[0].IsMain {
+		t.Error("rows[0].IsMain = false; main worktree must be first regardless of git list order")
+	}
 }

--- a/internal/treepad/tui.go
+++ b/internal/treepad/tui.go
@@ -30,7 +30,7 @@ var ErrNotTTY = errors.New("tp ui requires an interactive terminal")
 
 type (
 	uiTickMsg         struct{}
-	uiToastExpiredMsg struct{}
+	uiToastExpiredMsg struct{ gen int }
 	uiRefreshMsg      struct {
 		rows   []StatusRow
 		health map[string]healthFlags
@@ -96,6 +96,7 @@ type uiModel struct {
 	actionInFlight   bool   // sync in progress — pauses auto-refresh
 	syncBranch       string // branch being synced; empty = fleet sync
 	toast            *uiToast
+	toastGen         int
 	spinner          spinner.Model
 	mode             uiMode
 	confirmBranch    string // branch name shown in confirm modals

--- a/internal/treepad/tui_test.go
+++ b/internal/treepad/tui_test.go
@@ -1031,3 +1031,110 @@ func TestUIEmitCD(t *testing.T) {
 		}
 	})
 }
+
+func TestUINumberNavigation(t *testing.T) {
+	rows4 := []StatusRow{
+		{Branch: "main", IsMain: true, Path: "/repo/main"},
+		{Branch: "feat-a", Path: "/repo/feat-a"},
+		{Branch: "feat-b", Path: "/repo/feat-b"},
+		{Branch: "fix", Path: "/repo/fix"},
+	}
+
+	t.Run("number key jumps cursor to that row", func(t *testing.T) {
+		m := uiModel{rows: rows4, cursor: 0}
+		updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+		m2 := updated.(uiModel)
+		if m2.cursor != 2 {
+			t.Errorf("cursor = %d, want 2", m2.cursor)
+		}
+		if cmd != nil {
+			t.Error("in-range jump should not dispatch a command")
+		}
+	})
+
+	t.Run("0 jumps to first row", func(t *testing.T) {
+		m := uiModel{rows: rows4, cursor: 3}
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'0'}})
+		m2 := updated.(uiModel)
+		if m2.cursor != 0 {
+			t.Errorf("cursor = %d, want 0", m2.cursor)
+		}
+	})
+
+	t.Run("out-of-range shows toast and does not move cursor", func(t *testing.T) {
+		m := uiModel{rows: rows4, cursor: 1}
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'9'}})
+		m2 := updated.(uiModel)
+		if m2.cursor != 1 {
+			t.Errorf("cursor = %d, want 1 (unchanged)", m2.cursor)
+		}
+		if m2.toast == nil {
+			t.Fatal("expected out-of-range toast")
+		}
+		if !strings.Contains(m2.toast.msg, "out of range") {
+			t.Errorf("toast = %q, want containing 'out of range'", m2.toast.msg)
+		}
+		if m2.toast.isErr {
+			t.Error("out-of-range toast should not be sticky error")
+		}
+	})
+
+	t.Run("out-of-range increments toastGen so stale ticks do not clear toast", func(t *testing.T) {
+		m := uiModel{rows: rows4}
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'9'}})
+		m1 := updated.(uiModel)
+		gen1 := m1.toastGen
+
+		// second press bumps gen again
+		updated2, _ := m1.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'9'}})
+		m2 := updated2.(uiModel)
+		if m2.toastGen <= gen1 {
+			t.Errorf("toastGen = %d, want > %d after second press", m2.toastGen, gen1)
+		}
+
+		// stale tick (gen1) must not clear the current toast
+		updated3, _ := m2.Update(uiToastExpiredMsg{gen: gen1})
+		m3 := updated3.(uiModel)
+		if m3.toast == nil {
+			t.Error("stale tick should not clear toast set by later press")
+		}
+
+		// current tick (m2.toastGen) must clear
+		updated4, _ := m3.Update(uiToastExpiredMsg{gen: m2.toastGen})
+		m4 := updated4.(uiModel)
+		if m4.toast != nil {
+			t.Error("current-gen tick should clear the toast")
+		}
+	})
+
+	t.Run("number key in filter mode types character not navigates", func(t *testing.T) {
+		m := uiModel{rows: rows4, mode: uiModeFilter, filterStr: ""}
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+		m2 := updated.(uiModel)
+		if m2.filterStr != "2" {
+			t.Errorf("filterStr = %q, want '2'", m2.filterStr)
+		}
+		if m2.cursor != 0 {
+			t.Errorf("cursor = %d, want 0 (unchanged in filter mode)", m2.cursor)
+		}
+	})
+
+	t.Run("view shows row numbers as inline column prefix", func(t *testing.T) {
+		m := uiModel{rows: rows4, cursor: 0}
+		view := m.View()
+		if !strings.Contains(view, "0 ") {
+			t.Errorf("view missing '0 ' prefix: %s", view)
+		}
+		if !strings.Contains(view, "3 ") {
+			t.Errorf("view missing '3 ' prefix: %s", view)
+		}
+	})
+
+	t.Run("help text mentions number key navigation", func(t *testing.T) {
+		m := uiModel{mode: uiModeHelp}
+		view := m.View()
+		if !strings.Contains(view, "0–9") {
+			t.Errorf("help view missing '0–9' binding: %s", view)
+		}
+	})
+}

--- a/internal/treepad/tui_update.go
+++ b/internal/treepad/tui_update.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"time"
 
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
@@ -84,11 +85,12 @@ func (m uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.branch != "" {
 			label = msg.branch
 		}
+		m.toastGen++
 		m.toast = &uiToast{msg: fmt.Sprintf("✓ synced %s", label)}
-		return m, tea.Batch(m.doRefresh(), m.doTick(), m.doToastTimer())
+		return m, tea.Batch(m.doRefresh(), m.doTick(), m.timerCmd())
 
 	case uiToastExpiredMsg:
-		if m.toast != nil && !m.toast.isErr {
+		if msg.gen == m.toastGen && m.toast != nil && !m.toast.isErr {
 			m.toast = nil
 		}
 
@@ -98,8 +100,9 @@ func (m uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.toast = &uiToast{msg: fmt.Sprintf("%v", msg.err), isErr: true}
 			return m, nil
 		}
+		m.toastGen++
 		m.toast = &uiToast{msg: fmt.Sprintf("✓ opened %s", msg.path)}
-		return m, m.doToastTimer()
+		return m, m.timerCmd()
 
 	case uiDiffDoneMsg:
 		m.actionInFlight = false
@@ -107,8 +110,9 @@ func (m uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.toast = &uiToast{msg: fmt.Sprintf("%v", msg.err), isErr: true}
 			return m, nil
 		}
+		m.toastGen++
 		m.toast = &uiToast{msg: fmt.Sprintf("✓ diffed %s", msg.branch)}
-		return m, m.doToastTimer()
+		return m, m.timerCmd()
 
 	case uiShellDoneMsg:
 		m.actionInFlight = false
@@ -117,8 +121,9 @@ func (m uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.toast = &uiToast{msg: fmt.Sprintf("%v", msg.err), isErr: true}
 			return m, tea.Batch(m.doRefresh(), m.doTick())
 		}
+		m.toastGen++
 		m.toast = &uiToast{msg: fmt.Sprintf("✓ shell exited (%s)", msg.branch)}
-		return m, tea.Batch(m.doRefresh(), m.doTick(), m.doToastTimer())
+		return m, tea.Batch(m.doRefresh(), m.doTick(), m.timerCmd())
 
 	case uiYankClearMsg:
 		m.yankPath = ""
@@ -129,8 +134,9 @@ func (m uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.toast = &uiToast{msg: fmt.Sprintf("%v", msg.err), isErr: true}
 			return m, nil
 		}
+		m.toastGen++
 		m.toast = &uiToast{msg: fmt.Sprintf("✓ removed %s", msg.branch)}
-		return m, tea.Batch(m.doRefresh(), m.doTick(), m.doToastTimer())
+		return m, tea.Batch(m.doRefresh(), m.doTick(), m.timerCmd())
 
 	case uiPruneDoneMsg:
 		m.actionInFlight = false
@@ -138,8 +144,9 @@ func (m uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.toast = &uiToast{msg: fmt.Sprintf("%v", msg.err), isErr: true}
 			return m, nil
 		}
+		m.toastGen++
 		m.toast = &uiToast{msg: "✓ pruned merged worktrees"}
-		return m, tea.Batch(m.doRefresh(), m.doTick(), m.doToastTimer())
+		return m, tea.Batch(m.doRefresh(), m.doTick(), m.timerCmd())
 
 	case tea.KeyMsg:
 		// Filter mode intercepts all keystrokes for query editing.
@@ -278,8 +285,9 @@ func (m uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "y":
 			if row, ok := m.visibleCursorRow(); ok {
 				m.yankPath = row.Path
+				m.toastGen++
 				m.toast = &uiToast{msg: "📋 yanked " + row.Path}
-				return m, tea.Batch(m.doToastTimer(), func() tea.Msg { return uiYankClearMsg{} })
+				return m, tea.Batch(m.timerCmd(), func() tea.Msg { return uiYankClearMsg{} })
 			}
 		case "?":
 			m.mode = uiModeHelp
@@ -293,6 +301,19 @@ func (m uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.filterStr = ""
 				m.filterActive = false
 				m.cursor = 0
+			}
+		case "0", "1", "2", "3", "4", "5", "6", "7", "8", "9":
+			digit := int(msg.String()[0] - '0')
+			if digit < len(vr) {
+				m.cursor = digit
+			} else {
+				s := "s"
+				if len(vr) == 1 {
+					s = ""
+				}
+				m.toastGen++
+				m.toast = &uiToast{msg: fmt.Sprintf("row %d out of range (%d worktree%s)", digit, len(vr), s)}
+				return m, m.timerCmd()
 			}
 		case "up", "k":
 			if m.cursor > 0 {
@@ -437,9 +458,12 @@ func (m uiModel) doSyncFleet() tea.Cmd {
 	}
 }
 
-func (m uiModel) doToastTimer() tea.Cmd {
+func (m uiModel) timerCmd() tea.Cmd {
 	if m.toastTimerCmd == nil {
 		return nil
 	}
-	return m.toastTimerCmd()
+	gen := m.toastGen
+	return tea.Tick(2*time.Second, func(time.Time) tea.Msg {
+		return uiToastExpiredMsg{gen: gen}
+	})
 }

--- a/internal/treepad/tui_view.go
+++ b/internal/treepad/tui_view.go
@@ -44,12 +44,19 @@ func (m uiModel) View() string {
 		lines := formatUIRows(vr, m.health)
 		for i, line := range lines {
 			if i == 0 {
-				sb.WriteString("  ")
+				sb.WriteString("    ")
 				sb.WriteString(uiHeaderStyle.Render(line))
 			} else {
 				rowIdx := i - 1
 				isSyncing := m.actionInFlight && m.syncBranch != "" &&
 					rowIdx < len(vr) && vr[rowIdx].Branch == m.syncBranch
+
+				var numCol string
+				if rowIdx < 10 {
+					numCol = fmt.Sprintf("%d ", rowIdx)
+				} else {
+					numCol = "  "
+				}
 
 				var prefix string
 				switch {
@@ -65,11 +72,11 @@ func (m uiModel) View() string {
 					cwdInside(m.activePath, vr[rowIdx].Path)
 				switch {
 				case rowIdx == m.cursor:
-					sb.WriteString(uiCursorStyle.Render(prefix + line))
+					sb.WriteString(numCol + uiCursorStyle.Render(prefix+line))
 				case isActive:
-					sb.WriteString(uiActiveStyle.Render(prefix + line))
+					sb.WriteString(numCol + uiActiveStyle.Render(prefix+line))
 				default:
-					sb.WriteString(prefix + line)
+					sb.WriteString(numCol + prefix + line)
 				}
 			}
 			sb.WriteString("\n")
@@ -121,6 +128,7 @@ func (m uiModel) View() string {
 
 func uiRenderHelp() string {
 	body := "Key Bindings\n\n" +
+		"0–9         Jump to row N (row 0 = main worktree)\n" +
 		"↑ / k       Move cursor up\n" +
 		"↓ / j       Move cursor down\n" +
 		"Enter       cd into selected worktree\n" +


### PR DESCRIPTION
## Summary

- Pressing `0`–`9` in the TUI moves the cursor directly to that row index (`0` = main worktree)
- `collectStatusRows` now stable-sorts the main worktree first, guaranteeing row 0 is always the base worktree regardless of git's output order
- Out-of-range press (e.g. `5` with 4 rows) shows a transient toast; spamming resets the 2-second cooldown each time via a generation counter on `uiToastExpiredMsg` so stale ticks can't clear a newer toast
- Row numbers `0`–`9` rendered as an inline prefix column (outside cursor highlight); `?` help updated

## Test plan

- [ ] `go test ./internal/treepad/...` passes (275 tests)
- [ ] `tp ui` with ≥3 worktrees: press digit keys, cursor jumps; press an out-of-range digit, toast appears and re-arms on repeat; row numbers visible in table; `?` shows `0–9` binding
- [ ] Filter active + press `0`: jumps to first *visible* row

🤖 Generated with [Claude Code](https://claude.com/claude-code)