### PR TITLE
perf(new): recover sync optimisations and run checkout + sync concurrently

### DIFF
--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -10,11 +10,13 @@ import (
 	"time"
 )
 
-// Profiler records wall-time stage durations.
+// Profiler records wall-time stage durations and optional file-transfer metrics.
 // Call Stage to start a named stage and call the returned closure to end it.
 // Use as: defer p.Stage("foo")()
+// Call Observe after a stage to attach file/byte counts to its summary row.
 type Profiler interface {
 	Stage(name string) func()
+	Observe(name string, files, bytes int64)
 	Summary(w io.Writer, totalLabel string)
 }
 
@@ -38,13 +40,21 @@ func OrDisabled(p Profiler) Profiler {
 	return p
 }
 
+// IsEnabled reports whether p is an active (non-disabled) Profiler.
+// Use to gate expensive metric-collection work that should only run under --profile.
+func IsEnabled(p Profiler) bool {
+	return p != nil && p != sharedDisabled
+}
+
 type entry struct {
 	dur   time.Duration
+	files int64
+	bytes int64
 	order int
 }
 
 // Recorder is a Profiler that accumulates wall-time durations per named stage.
-// Repeated calls to Stage with the same name add to the existing total.
+// Repeated calls to Stage or Observe with the same name add to the existing total.
 type Recorder struct {
 	mu      sync.Mutex
 	entries map[string]*entry
@@ -68,20 +78,39 @@ func (r *Recorder) Stage(name string) func() {
 	}
 }
 
+// Observe records file and byte counts for name, adding to any existing totals.
+func (r *Recorder) Observe(name string, files, bytes int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if e, ok := r.entries[name]; ok {
+		e.files += files
+		e.bytes += bytes
+	} else {
+		r.counter++
+		r.entries[name] = &entry{files: files, bytes: bytes, order: r.counter}
+	}
+}
+
 // Summary writes a timing table to w, sorted by duration descending.
 // The row with the longest duration is marked with ◀.
+// Files and bytes columns are shown only when at least one stage has non-zero counts.
 func (r *Recorder) Summary(w io.Writer, totalLabel string) {
 	r.mu.Lock()
 	type row struct {
 		name  string
 		dur   time.Duration
+		files int64
+		bytes int64
 		order int
 	}
 	rows := make([]row, 0, len(r.entries))
 	var total time.Duration
+	var totalFiles, totalBytes int64
 	for name, e := range r.entries {
-		rows = append(rows, row{name: name, dur: e.dur, order: e.order})
+		rows = append(rows, row{name: name, dur: e.dur, files: e.files, bytes: e.bytes, order: e.order})
 		total += e.dur
+		totalFiles += e.files
+		totalBytes += e.bytes
 	}
 	r.mu.Unlock()
 
@@ -103,10 +132,37 @@ func (r *Recorder) Summary(w io.Writer, totalLabel string) {
 		}
 	}
 
-	sep := strings.Repeat("─", nameWidth) + "  " + strings.Repeat("─", 10) + "  " + strings.Repeat("─", 6)
+	const (
+		durWidth   = 10
+		filesWidth = 9
+		bytesWidth = 9
+		pctWidth   = 6
+	)
+
+	showMetrics := totalFiles > 0 || totalBytes > 0
+
+	var sep string
+	if showMetrics {
+		sep = strings.Repeat("─", nameWidth) + "  " +
+			strings.Repeat("─", durWidth) + "  " +
+			strings.Repeat("─", filesWidth) + "  " +
+			strings.Repeat("─", bytesWidth) + "  " +
+			strings.Repeat("─", pctWidth)
+	} else {
+		sep = strings.Repeat("─", nameWidth) + "  " +
+			strings.Repeat("─", durWidth) + "  " +
+			strings.Repeat("─", pctWidth)
+	}
+
 	_, _ = fmt.Fprintf(w, "\nprofile: %s (total %s)\n", totalLabel, fmtDur(total))
-	_, _ = fmt.Fprintf(w, "  %-*s  %-10s  %s\n", nameWidth, "stage", "duration", "   pct")
+	if showMetrics {
+		_, _ = fmt.Fprintf(w, "  %-*s  %-*s  %*s  %*s  %s\n",
+			nameWidth, "stage", durWidth, "duration", filesWidth, "files", bytesWidth, "bytes", "   pct")
+	} else {
+		_, _ = fmt.Fprintf(w, "  %-*s  %-*s  %s\n", nameWidth, "stage", durWidth, "duration", "   pct")
+	}
 	_, _ = fmt.Fprintf(w, "  %s\n", sep)
+
 	for i, ro := range rows {
 		pct := 0.0
 		if total > 0 {
@@ -116,21 +172,78 @@ func (r *Recorder) Summary(w io.Writer, totalLabel string) {
 		if i == 0 && len(rows) > 1 {
 			marker = "  ◀"
 		}
-		_, _ = fmt.Fprintf(w, "  %-*s  %-10s  %5.1f%%%s\n", nameWidth, ro.name, fmtDur(ro.dur), pct, marker)
+		if showMetrics {
+			_, _ = fmt.Fprintf(w, "  %-*s  %-*s  %*s  %*s  %5.1f%%%s\n",
+				nameWidth, ro.name, durWidth, fmtDur(ro.dur),
+				filesWidth, fmtCount(ro.files), bytesWidth, fmtBytes(ro.bytes),
+				pct, marker)
+		} else {
+			_, _ = fmt.Fprintf(w, "  %-*s  %-*s  %5.1f%%%s\n", nameWidth, ro.name, durWidth, fmtDur(ro.dur), pct, marker)
+		}
 	}
+
 	_, _ = fmt.Fprintf(w, "  %s\n", sep)
-	_, _ = fmt.Fprintf(w, "  %-*s  %-10s  100.0%%\n\n", nameWidth, "total", fmtDur(total))
+	if showMetrics {
+		_, _ = fmt.Fprintf(w, "  %-*s  %-*s  %*s  %*s  100.0%%\n\n",
+			nameWidth, "total", durWidth, fmtDur(total),
+			filesWidth, fmtCount(totalFiles), bytesWidth, fmtBytes(totalBytes))
+	} else {
+		_, _ = fmt.Fprintf(w, "  %-*s  %-*s  100.0%%\n\n", nameWidth, "total", durWidth, fmtDur(total))
+	}
 }
 
 func fmtDur(d time.Duration) string {
-	return fmt.Sprintf("%.3fs", d.Seconds())
+	if d >= time.Second {
+		return fmt.Sprintf("%.3fs", d.Seconds())
+	}
+	return fmt.Sprintf("%dms", d.Milliseconds())
+}
+
+func fmtCount(n int64) string {
+	if n == 0 {
+		return "-"
+	}
+	s := fmt.Sprintf("%d", n)
+	var b []byte
+	for i := range len(s) {
+		if i > 0 && (len(s)-i)%3 == 0 {
+			b = append(b, ',')
+		}
+		b = append(b, s[i])
+	}
+	return string(b)
+}
+
+func fmtBytes(n int64) string {
+	if n == 0 {
+		return "-"
+	}
+	const (
+		kb = 1024
+		mb = 1024 * kb
+		gb = 1024 * mb
+		tb = 1024 * gb
+	)
+	switch {
+	case n >= tb:
+		return fmt.Sprintf("%.1f TB", float64(n)/tb)
+	case n >= gb:
+		return fmt.Sprintf("%.1f GB", float64(n)/gb)
+	case n >= mb:
+		return fmt.Sprintf("%.1f MB", float64(n)/mb)
+	case n >= kb:
+		return fmt.Sprintf("%.1f KB", float64(n)/kb)
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
 }
 
 type noopProfiler struct{}
 
 var disabledDone = func() {}
 
-func (noopProfiler) Stage(_ string) func()         { return disabledDone }
-func (noopProfiler) Summary(_ io.Writer, _ string) {}
+func (noopProfiler) Stage(_ string) func()              { return disabledDone }
+func (noopProfiler) Observe(_ string, _, _ int64)       {}
+func (noopProfiler) Summary(_ io.Writer, _ string)      {}
 
 var sharedDisabled Profiler = noopProfiler{}

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -242,8 +242,8 @@ type noopProfiler struct{}
 
 var disabledDone = func() {}
 
-func (noopProfiler) Stage(_ string) func()              { return disabledDone }
-func (noopProfiler) Observe(_ string, _, _ int64)       {}
-func (noopProfiler) Summary(_ io.Writer, _ string)      {}
+func (noopProfiler) Stage(_ string) func()         { return disabledDone }
+func (noopProfiler) Observe(_ string, _, _ int64)  {}
+func (noopProfiler) Summary(_ io.Writer, _ string) {}
 
 var sharedDisabled Profiler = noopProfiler{}

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -135,12 +135,151 @@ func TestDisabled(t *testing.T) {
 	p := Disabled()
 	for range 1000 {
 		p.Stage("x")()
+		p.Observe("x", 1, 1024)
 	}
 	var buf bytes.Buffer
 	p.Summary(&buf, "test")
 	if buf.Len() != 0 {
 		t.Errorf("Disabled.Summary wrote %d bytes, want 0", buf.Len())
 	}
+}
+
+func TestIsEnabled(t *testing.T) {
+	if IsEnabled(nil) {
+		t.Error("nil should not be enabled")
+	}
+	if IsEnabled(Disabled()) {
+		t.Error("Disabled() should not be enabled")
+	}
+	if !IsEnabled(NewRecorder()) {
+		t.Error("NewRecorder() should be enabled")
+	}
+}
+
+func TestRecorder_Observe(t *testing.T) {
+	r := &Recorder{
+		entries: make(map[string]*entry),
+		nowFunc: time.Now,
+	}
+
+	r.Observe("file_sync", 10, 1024)
+	r.Observe("file_sync", 5, 512)
+
+	e := r.entries["file_sync"]
+	if e.files != 15 {
+		t.Errorf("files = %d, want 15", e.files)
+	}
+	if e.bytes != 1536 {
+		t.Errorf("bytes = %d, want 1536", e.bytes)
+	}
+
+	r.Observe("other", 1, 100)
+	if r.entries["other"].files != 1 {
+		t.Error("new entry via Observe not created")
+	}
+}
+
+func TestFmtDur(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{999 * time.Millisecond, "999ms"},
+		{500 * time.Millisecond, "500ms"},
+		{1 * time.Millisecond, "1ms"},
+		{0, "0ms"},
+		{time.Second, "1.000s"},
+		{1500 * time.Millisecond, "1.500s"},
+		{12345 * time.Millisecond, "12.345s"},
+	}
+	for _, tt := range tests {
+		if got := fmtDur(tt.d); got != tt.want {
+			t.Errorf("fmtDur(%v) = %q, want %q", tt.d, got, tt.want)
+		}
+	}
+}
+
+func TestFmtCount(t *testing.T) {
+	tests := []struct {
+		n    int64
+		want string
+	}{
+		{0, "-"},
+		{1, "1"},
+		{999, "999"},
+		{1000, "1,000"},
+		{38412, "38,412"},
+		{1000000, "1,000,000"},
+	}
+	for _, tt := range tests {
+		if got := fmtCount(tt.n); got != tt.want {
+			t.Errorf("fmtCount(%d) = %q, want %q", tt.n, got, tt.want)
+		}
+	}
+}
+
+func TestFmtBytes(t *testing.T) {
+	tests := []struct {
+		n    int64
+		want string
+	}{
+		{0, "-"},
+		{512, "512 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1024 * 1024, "1.0 MB"},
+		{int64(1.5 * 1024 * 1024), "1.5 MB"},
+		{1024 * 1024 * 1024, "1.0 GB"},
+		{1024 * 1024 * 1024 * 1024, "1.0 TB"},
+	}
+	for _, tt := range tests {
+		if got := fmtBytes(tt.n); got != tt.want {
+			t.Errorf("fmtBytes(%d) = %q, want %q", tt.n, got, tt.want)
+		}
+	}
+}
+
+func TestRecorder_Summary_MetricsColumns(t *testing.T) {
+	t.Run("columns hidden when no metrics", func(t *testing.T) {
+		r := &Recorder{
+			entries: map[string]*entry{
+				"git.worktree_add": {dur: time.Second, order: 1},
+			},
+			counter: 1,
+			nowFunc: time.Now,
+		}
+		var buf bytes.Buffer
+		r.Summary(&buf, "cmd")
+		out := buf.String()
+		if strings.Contains(out, "files") || strings.Contains(out, "bytes") {
+			t.Errorf("files/bytes columns should be hidden when no metrics:\n%s", out)
+		}
+	})
+
+	t.Run("columns shown when metrics present", func(t *testing.T) {
+		r := &Recorder{
+			entries: map[string]*entry{
+				"file_sync":        {dur: 8 * time.Second, files: 38412, bytes: 1200000000, order: 1},
+				"git.worktree_add": {dur: 142 * time.Millisecond, order: 2},
+			},
+			counter: 2,
+			nowFunc: time.Now,
+		}
+		var buf bytes.Buffer
+		r.Summary(&buf, "tp new")
+		out := buf.String()
+		for _, want := range []string{"files", "bytes", "38,412", "1.1 GB", "-"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("Summary missing %q:\n%s", want, out)
+			}
+		}
+		if !strings.Contains(out, "142ms") {
+			t.Errorf("sub-second duration should render as ms:\n%s", out)
+		}
+		if !strings.Contains(out, "8.000s") {
+			t.Errorf("second-range duration should render as seconds:\n%s", out)
+		}
+	})
 }
 
 // stepClock returns a nowFunc that advances by step on each call, so that

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -92,19 +92,7 @@ func (FileSyncer) Sync(patterns []string, cfg Config) (SyncResult, error) {
 			walkIncludes = append(walkIncludes, p)
 			continue
 		}
-		// Stat-walk the source to count files and bytes for the cloned tree.
-		_ = filepath.WalkDir(src, func(_ string, d fs.DirEntry, err error) error {
-			if err != nil || d.IsDir() {
-				return nil
-			}
-			result.Files++
-			if d.Type().IsRegular() {
-				if info, e := d.Info(); e == nil {
-					result.Bytes += info.Size()
-				}
-			}
-			return nil
-		})
+		result.Files++ // one entry per cloned tree; no source walk needed
 		cloned[dir] = true
 		slog.Debug("cloned tree", "dir", dir)
 	}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -45,7 +45,6 @@ func stageOf(cfg Config) func(string) func() {
 // SyncResult holds file-transfer metrics from a Sync call.
 type SyncResult struct {
 	Files int64
-	Bytes int64
 }
 
 // Syncer copies files matching patterns from SourceDir to TargetDir.
@@ -151,9 +150,6 @@ func (FileSyncer) Sync(patterns []string, cfg Config) (SyncResult, error) {
 			return fmt.Errorf("sync %s: %w", rel, err)
 		}
 		result.Files++
-		if info, e := d.Info(); e == nil {
-			result.Bytes += info.Size()
-		}
 		return nil
 	})
 	walkDone()

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -30,6 +30,16 @@ func CloneTree(src, dst string) error { return cloneTree(src, dst) }
 type Config struct {
 	SourceDir string
 	TargetDir string
+	// Stage is an optional profiler hook; nil means no-op.
+	// Call: done := cfg.Stage("name"); defer done()
+	Stage func(string) func()
+}
+
+func stageOf(cfg Config) func(string) func() {
+	if cfg.Stage != nil {
+		return cfg.Stage
+	}
+	return func(_ string) func() { return func() {} }
 }
 
 // SyncResult holds file-transfer metrics from a Sync call.
@@ -54,6 +64,7 @@ func (FileSyncer) Sync(patterns []string, cfg Config) (SyncResult, error) {
 		return SyncResult{}, err
 	}
 	include, exclude := parsePatterns(patterns)
+	stage := stageOf(cfg)
 
 	var result SyncResult
 
@@ -61,6 +72,7 @@ func (FileSyncer) Sync(patterns []string, cfg Config) (SyncResult, error) {
 	// On Darwin/APFS this turns a 30s node_modules copy into a sub-second clone.
 	cloned := make(map[string]bool)
 	var walkIncludes []string
+	cloneDone := stage("sync.clone_pass")
 	for _, p := range include {
 		dir, ok := wholeDirPattern(p)
 		if !ok || !canFastClone(dir, exclude) {
@@ -96,7 +108,14 @@ func (FileSyncer) Sync(patterns []string, cfg Config) (SyncResult, error) {
 		cloned[dir] = true
 		slog.Debug("cloned tree", "dir", dir)
 	}
+	cloneDone()
 
+	if len(walkIncludes) == 0 {
+		return result, nil
+	}
+
+	madeDir := make(map[string]struct{})
+	walkDone := stage("sync.walk")
 	err := filepath.WalkDir(cfg.SourceDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -113,7 +132,7 @@ func (FileSyncer) Sync(patterns []string, cfg Config) (SyncResult, error) {
 				return nil
 			}
 			dst := filepath.Join(cfg.TargetDir, rel)
-			if err := copySymlink(path, dst); err != nil {
+			if err := copySymlinkCached(path, dst, madeDir); err != nil {
 				return fmt.Errorf("sync %s: %w", rel, err)
 			}
 			result.Files++
@@ -140,7 +159,7 @@ func (FileSyncer) Sync(patterns []string, cfg Config) (SyncResult, error) {
 
 		slog.Debug("syncing file", "rel", rel)
 		dst := filepath.Join(cfg.TargetDir, rel)
-		if err := copyFile(path, dst); err != nil {
+		if err := copyFileCached(path, dst, madeDir); err != nil {
 			return fmt.Errorf("sync %s: %w", rel, err)
 		}
 		result.Files++
@@ -149,6 +168,7 @@ func (FileSyncer) Sync(patterns []string, cfg Config) (SyncResult, error) {
 		}
 		return nil
 	})
+	walkDone()
 	return result, err
 }
 
@@ -266,12 +286,16 @@ func dirCouldMatch(dir string, includes []string) bool {
 }
 
 func copySymlink(src, dst string) error {
+	return copySymlinkCached(src, dst, nil)
+}
+
+func copySymlinkCached(src, dst string, made map[string]struct{}) error {
 	target, err := os.Readlink(src)
 	if err != nil {
 		return fmt.Errorf("read symlink: %w", err)
 	}
-	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-		return fmt.Errorf("create destination directory: %w", err)
+	if err := ensureParentDir(dst, made); err != nil {
+		return err
 	}
 	if err := os.Remove(dst); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("remove existing destination: %w", err)
@@ -283,8 +307,12 @@ func copySymlink(src, dst string) error {
 }
 
 func copyFile(src, dst string) error {
-	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-		return fmt.Errorf("create destination directory: %w", err)
+	return copyFileCached(src, dst, nil)
+}
+
+func copyFileCached(src, dst string, made map[string]struct{}) error {
+	if err := ensureParentDir(dst, made); err != nil {
+		return err
 	}
 	if err := cloneFile(src, dst); !errors.Is(err, errCloneUnsupported) {
 		return err
@@ -305,4 +333,21 @@ func copyFile(src, dst string) error {
 		return fmt.Errorf("copy data: %w", err)
 	}
 	return out.Close()
+}
+
+// ensureParentDir calls MkdirAll on dir(dst) at most once per run when made is non-nil.
+func ensureParentDir(dst string, made map[string]struct{}) error {
+	dir := filepath.Dir(dst)
+	if made != nil {
+		if _, ok := made[dir]; ok {
+			return nil
+		}
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create destination directory: %w", err)
+	}
+	if made != nil {
+		made[dir] = struct{}{}
+	}
+	return nil
 }

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -285,10 +285,6 @@ func dirCouldMatch(dir string, includes []string) bool {
 	return false
 }
 
-func copySymlink(src, dst string) error {
-	return copySymlinkCached(src, dst, nil)
-}
-
 func copySymlinkCached(src, dst string, made map[string]struct{}) error {
 	target, err := os.Readlink(src)
 	if err != nil {

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -32,22 +32,30 @@ type Config struct {
 	TargetDir string
 }
 
+// SyncResult holds file-transfer metrics from a Sync call.
+type SyncResult struct {
+	Files int64
+	Bytes int64
+}
+
 // Syncer copies files matching patterns from SourceDir to TargetDir.
 // Patterns follow gitignore syntax: ** matches across directories,
 // trailing / matches a directory and all its contents,
 // and ! prefix negates a pattern.
 // Files absent in SourceDir are silently skipped.
 type Syncer interface {
-	Sync(patterns []string, cfg Config) error
+	Sync(patterns []string, cfg Config) (SyncResult, error)
 }
 
 type FileSyncer struct{}
 
-func (FileSyncer) Sync(patterns []string, cfg Config) error {
+func (FileSyncer) Sync(patterns []string, cfg Config) (SyncResult, error) {
 	if err := validatePatterns(patterns); err != nil {
-		return err
+		return SyncResult{}, err
 	}
 	include, exclude := parsePatterns(patterns)
+
+	var result SyncResult
 
 	// Attempt to fast-clone whole-directory include patterns before walking.
 	// On Darwin/APFS this turns a 30s node_modules copy into a sub-second clone.
@@ -72,11 +80,24 @@ func (FileSyncer) Sync(patterns []string, cfg Config) error {
 			walkIncludes = append(walkIncludes, p)
 			continue
 		}
+		// Stat-walk the source to count files and bytes for the cloned tree.
+		_ = filepath.WalkDir(src, func(_ string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil
+			}
+			result.Files++
+			if d.Type().IsRegular() {
+				if info, e := d.Info(); e == nil {
+					result.Bytes += info.Size()
+				}
+			}
+			return nil
+		})
 		cloned[dir] = true
 		slog.Debug("cloned tree", "dir", dir)
 	}
 
-	return filepath.WalkDir(cfg.SourceDir, func(path string, d fs.DirEntry, err error) error {
+	err := filepath.WalkDir(cfg.SourceDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -95,6 +116,7 @@ func (FileSyncer) Sync(patterns []string, cfg Config) error {
 			if err := copySymlink(path, dst); err != nil {
 				return fmt.Errorf("sync %s: %w", rel, err)
 			}
+			result.Files++
 			slog.Debug("synced symlink", "rel", rel)
 			return nil
 		}
@@ -121,8 +143,13 @@ func (FileSyncer) Sync(patterns []string, cfg Config) error {
 		if err := copyFile(path, dst); err != nil {
 			return fmt.Errorf("sync %s: %w", rel, err)
 		}
+		result.Files++
+		if info, e := d.Info(); e == nil {
+			result.Bytes += info.Size()
+		}
 		return nil
 	})
+	return result, err
 }
 
 func parsePatterns(patterns []string) (include, exclude []string) {

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -415,6 +416,46 @@ func TestWholeDirPattern(t *testing.T) {
 		if dir != tt.wantDir || ok != tt.wantOK {
 			t.Errorf("wholeDirPattern(%q) = (%q, %v), want (%q, %v)", tt.pattern, dir, ok, tt.wantDir, tt.wantOK)
 		}
+	}
+}
+
+func TestClonePassDoesNotEnumerateClonedTree(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("APFS clonefile required for fast-clone path")
+	}
+	src := t.TempDir()
+	dst := t.TempDir()
+	sub := filepath.Join(src, "node_modules")
+	const leafCount = 5000
+	for i := 0; i < leafCount; i++ {
+		writeFile(t, filepath.Join(sub, fmt.Sprintf("pkg%d", i), "index.js"), "x")
+	}
+
+	stageDur := map[string]time.Duration{}
+	res, err := FileSyncer{}.Sync([]string{"node_modules/"}, Config{
+		SourceDir: src,
+		TargetDir: dst,
+		Stage: func(name string) func() {
+			t0 := time.Now()
+			return func() { stageDur[name] = time.Since(t0) }
+		},
+	})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	// Primary deterministic check: clone-pass must not enumerate every leaf.
+	if res.Files >= leafCount {
+		t.Errorf("SyncResult.Files = %d (>= leaf count %d): clone_pass is walking the source tree",
+			res.Files, leafCount)
+	}
+	// Sanity: the clone actually happened.
+	if _, err := os.Stat(filepath.Join(dst, "node_modules", "pkg0", "index.js")); err != nil {
+		t.Errorf("expected cloned file present: %v", err)
+	}
+	// Soft perf guard: generous threshold relative to expected <10 ms.
+	if d := stageDur["sync.clone_pass"]; d > 500*time.Millisecond {
+		t.Errorf("sync.clone_pass = %v, expected < 500ms (stat-walk likely reintroduced)", d)
 	}
 }
 

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -221,7 +221,7 @@ func TestFileSyncerSync(t *testing.T) {
 			dst := t.TempDir()
 			tt.setup(src)
 
-			err := FileSyncer{}.Sync(tt.patterns, Config{SourceDir: src, TargetDir: dst})
+			_, err := FileSyncer{}.Sync(tt.patterns, Config{SourceDir: src, TargetDir: dst})
 
 			if tt.wantErr != "" {
 				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
@@ -328,7 +328,7 @@ func TestFileSyncerSyncFastPath(t *testing.T) {
 			dst := t.TempDir()
 			tt.setup(src)
 
-			err := FileSyncer{}.Sync(tt.patterns, Config{SourceDir: src, TargetDir: dst})
+			_, err := FileSyncer{}.Sync(tt.patterns, Config{SourceDir: src, TargetDir: dst})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -358,13 +358,13 @@ func TestFileSyncerSyncBudget(t *testing.T) {
 	}
 
 	start := time.Now()
-	err := FileSyncer{}.Sync([]string{"node_modules/"}, Config{SourceDir: src, TargetDir: dst})
+	res, err := FileSyncer{}.Sync([]string{"node_modules/"}, Config{SourceDir: src, TargetDir: dst})
 	elapsed := time.Since(start)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	t.Logf("synced %d files in %v", pkgCount*filesPerPkg, elapsed)
+	t.Logf("synced %d files (%d bytes) in %v", res.Files, res.Bytes, elapsed)
 	if elapsed > budget {
 		t.Errorf("sync took %v, want < %v — possible regression to slow copy path", elapsed, budget)
 	}

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -342,6 +342,9 @@ func TestFileSyncerSyncFastPath(t *testing.T) {
 // tree completes within a usable time budget. On APFS (Darwin) the fast-clone
 // path makes this near-instant; on Linux the budget covers kernel-copy overhead.
 func TestFileSyncerSyncBudget(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("fast-clone path (clonefile) is Darwin/APFS only")
+	}
 	const (
 		pkgCount    = 20
 		filesPerPkg = 1000

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -365,7 +365,7 @@ func TestFileSyncerSyncBudget(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	t.Logf("synced %d files (%d bytes) in %v", res.Files, res.Bytes, elapsed)
+	t.Logf("synced %d files in %v", res.Files, elapsed)
 	if elapsed > budget {
 		t.Errorf("sync took %v, want < %v — possible regression to slow copy path", elapsed, budget)
 	}

--- a/internal/treepad/fromspec/bulk_test.go
+++ b/internal/treepad/fromspec/bulk_test.go
@@ -23,7 +23,7 @@ func fakeIssueJSON(title, body string) []byte {
 }
 
 // bulkSeqResponses builds seqRunner responses for N happy-path issues.
-// Per issue: gh response, git worktree list, git worktree add.
+// Per issue: gh response, git worktree list, git worktree add --no-checkout, git checkout.
 func bulkSeqResponses(mainPath string, issues []struct{ title, body string }) []treepadtest.RunResponse {
 	porcelain := treepadtest.MainWorktreePorcelain(mainPath)
 	var responses []treepadtest.RunResponse
@@ -31,7 +31,8 @@ func bulkSeqResponses(mainPath string, issues []struct{ title, body string }) []
 		responses = append(responses,
 			treepadtest.RunResponse{Output: fakeIssueJSON(issue.title, issue.body)},
 			treepadtest.RunResponse{Output: porcelain},
-			treepadtest.RunResponse{Output: nil},
+			treepadtest.RunResponse{Output: nil}, // git worktree add --no-checkout
+			treepadtest.RunResponse{Output: nil}, // git checkout
 		)
 	}
 	return responses
@@ -114,11 +115,13 @@ func TestFromSpecBulk(t *testing.T) {
 		runner := &treepadtest.SeqRunner{Responses: []treepadtest.RunResponse{
 			{Output: fakeIssueJSON("Add retry", "implement retry")},
 			{Output: porcelain},
-			{Output: nil},
-			{Output: fakeIssueJSON("Empty issue", "")}, // empty body
+			{Output: nil}, // git worktree add --no-checkout
+			{Output: nil}, // git checkout
+			{Output: fakeIssueJSON("Empty issue", "")}, // empty body — no worktree created
 			{Output: fakeIssueJSON("Fix auth", "patch oauth")},
 			{Output: porcelain},
-			{Output: nil},
+			{Output: nil}, // git worktree add --no-checkout
+			{Output: nil}, // git checkout
 		}}
 		var logBuf bytes.Buffer
 		deps := deps.Deps{Runner: runner, Syncer: &treepadtest.FakeSyncer{}, Opener: &treepadtest.FakeOpener{}}
@@ -155,11 +158,13 @@ func TestFromSpecBulk(t *testing.T) {
 		runner := &treepadtest.SeqRunner{Responses: []treepadtest.RunResponse{
 			{Output: fakeIssueJSON("Add retry", "implement retry")},
 			{Output: porcelain},
-			{Output: nil},
-			{Output: nil, Err: treepadtest.ErrExitNonZero},
+			{Output: nil}, // git worktree add --no-checkout
+			{Output: nil}, // git checkout
+			{Output: nil, Err: treepadtest.ErrExitNonZero}, // gh issue view fails
 			{Output: fakeIssueJSON("Fix auth", "patch oauth")},
 			{Output: porcelain},
-			{Output: nil},
+			{Output: nil}, // git worktree add --no-checkout
+			{Output: nil}, // git checkout
 		}}
 		var logBuf bytes.Buffer
 		deps := deps.Deps{Runner: runner, Syncer: &treepadtest.FakeSyncer{}, Opener: &treepadtest.FakeOpener{}}
@@ -190,10 +195,12 @@ func TestFromSpecBulk(t *testing.T) {
 		runner := &treepadtest.SeqRunner{Responses: []treepadtest.RunResponse{
 			{Output: fakeIssueJSON("Duplicate Title", "spec body one")},
 			{Output: porcelain},
-			{Output: nil},
+			{Output: nil}, // git worktree add --no-checkout
+			{Output: nil}, // git checkout
 			{Output: fakeIssueJSON("Duplicate Title", "spec body two")},
 			{Output: porcelain},
-			{Output: nil},
+			{Output: nil}, // git worktree add --no-checkout
+			{Output: nil}, // git checkout
 		}}
 		deps := deps.Deps{Runner: runner, Syncer: &treepadtest.FakeSyncer{}, Opener: &treepadtest.FakeOpener{}}
 		var logBuf bytes.Buffer
@@ -226,7 +233,8 @@ func TestFromSpecBulk(t *testing.T) {
 		runner := &treepadtest.SeqRunner{Responses: []treepadtest.RunResponse{
 			{Output: fakeIssueJSON("Some feature", "do the thing")},
 			{Output: porcelain},
-			{Output: nil},
+			{Output: nil}, // git worktree add --no-checkout
+			{Output: nil}, // git checkout
 		}}
 		pt := &treepadtest.FakePassthroughRunner{}
 		deps := deps.Deps{Runner: runner, Syncer: &treepadtest.FakeSyncer{}, Opener: &treepadtest.FakeOpener{}}
@@ -251,7 +259,8 @@ func TestFromSpecBulk(t *testing.T) {
 		runner := &treepadtest.SeqRunner{Responses: []treepadtest.RunResponse{
 			{Output: fakeIssueJSON("Some feature", "do the thing")},
 			{Output: porcelain},
-			{Output: nil},
+			{Output: nil}, // git worktree add --no-checkout
+			{Output: nil}, // git checkout
 		}}
 		var stdout bytes.Buffer
 		var logBuf bytes.Buffer

--- a/internal/treepad/fromspec/from_spec_test.go
+++ b/internal/treepad/fromspec/from_spec_test.go
@@ -230,7 +230,8 @@ agent_command = []
 		rr := &treepadtest.RecordingRunner{Inner: &treepadtest.SeqRunner{Responses: []treepadtest.RunResponse{
 			{Output: []byte(specBody)}, // gh issue view
 			{Output: porcelain},        // git worktree list
-			{Output: nil},              // git worktree add
+			{Output: nil},              // git worktree add --no-checkout
+			{Output: nil},              // git checkout
 		}}}
 		deps := deps.Deps{
 			Runner: rr,
@@ -271,7 +272,8 @@ agent_command = []
 		runner := &treepadtest.SeqRunner{Responses: []treepadtest.RunResponse{
 			{Output: []byte(specBody)}, // gh issue view
 			{Output: porcelain},        // git worktree list
-			{Output: nil},              // git worktree add
+			{Output: nil},              // git worktree add --no-checkout
+			{Output: nil},              // git checkout
 		}}
 		pt := &treepadtest.FakePassthroughRunner{}
 		deps := deps.Deps{Runner: runner, Syncer: &treepadtest.FakeSyncer{}, Opener: &treepadtest.FakeOpener{}}
@@ -303,7 +305,8 @@ agent_command = []
 		runner := &treepadtest.SeqRunner{Responses: []treepadtest.RunResponse{
 			{Output: []byte(specBody)}, // gh issue view
 			{Output: porcelain},        // git worktree list
-			{Output: nil},              // git worktree add
+			{Output: nil},              // git worktree add --no-checkout
+			{Output: nil},              // git checkout
 		}}
 		deps := deps.Deps{Runner: runner, Syncer: &treepadtest.FakeSyncer{}, Opener: &treepadtest.FakeOpener{}}
 		deps.PTRunner = &treepadtest.FakePassthroughRunner{}
@@ -357,7 +360,8 @@ agent_command = []
 		runner := &treepadtest.SeqRunner{Responses: []treepadtest.RunResponse{
 			{Output: []byte(specBody)}, // gh issue view
 			{Output: porcelain},        // git worktree list
-			{Output: nil},              // git worktree add
+			{Output: nil},              // git worktree add --no-checkout
+			{Output: nil},              // git checkout
 		}}
 		hr := &treepadtest.FakeHookRunner{}
 		deps := deps.Deps{Runner: runner, Syncer: &treepadtest.FakeSyncer{}, Opener: &treepadtest.FakeOpener{}}
@@ -418,7 +422,8 @@ agent_command = []
 		runner := &treepadtest.SeqRunner{Responses: []treepadtest.RunResponse{
 			{Output: []byte(specBody)}, // gh issue view
 			{Output: porcelain},        // git worktree list
-			{Output: nil},              // git worktree add
+			{Output: nil},              // git worktree add --no-checkout
+			{Output: nil},              // git checkout
 		}}
 		var buf bytes.Buffer
 		deps := deps.Deps{Runner: runner, Syncer: &treepadtest.FakeSyncer{}, Opener: &treepadtest.FakeOpener{}}

--- a/internal/treepad/lifecycle/lifecycle.go
+++ b/internal/treepad/lifecycle/lifecycle.go
@@ -88,6 +88,9 @@ func CreateWorktreeWithSync(ctx context.Context, d deps.Deps, branch, base, outp
 		if artErr != nil {
 			return fmt.Errorf("write artifact: %w", artErr)
 		}
+		if info, statErr := os.Stat(artifactPath); statErr == nil {
+			p.Observe("artifact.write", 1, info.Size())
+		}
 		slog.Debug("wrote artifact", "outputDir", rc.OutputDir, "branch", branch)
 		return nil
 	})
@@ -167,11 +170,12 @@ func LoadAndSync(
 		}
 		postErr, err := hook.RunSandwich(ctx, p, d.HookRunner, cfg.Hooks, hook.PreSync, hook.PostSync, hData, func() error {
 			fileSyncDone := p.Stage("file_sync")
-			syncErr := d.Syncer.Sync(patterns, internalsync.Config{
+			syncRes, syncErr := d.Syncer.Sync(patterns, internalsync.Config{
 				SourceDir: sourceDir,
 				TargetDir: t.Path,
 			})
 			fileSyncDone()
+			p.Observe("file_sync", syncRes.Files, syncRes.Bytes)
 			if syncErr != nil {
 				return fmt.Errorf("sync configs to %s: %w", t.Branch, syncErr)
 			}
@@ -232,9 +236,14 @@ func doRemove(
 
 	pre, post := hook.PreRemove, hook.PostRemove
 	postErr, err := hook.RunSandwich(ctx, p, d.HookRunner, cfg.Hooks, pre, post, hData, func() error {
+		var removeFiles, removeBytes int64
+		if profile.IsEnabled(p) {
+			removeFiles, removeBytes = statTree(target.Path)
+		}
 		wtRemoveDone := p.Stage("git.worktree_remove")
 		_, wtErr := d.Runner.Run(ctx, "git", removeArgs...)
 		wtRemoveDone()
+		p.Observe("git.worktree_remove", removeFiles, removeBytes)
 		if wtErr != nil {
 			return fmt.Errorf("%s: %w", removeVerb, wtErr)
 		}
@@ -251,9 +260,14 @@ func doRemove(
 			if !ok {
 				return nil
 			}
+			var artSize int64
+			if info, statErr := os.Stat(artifactPath); statErr == nil {
+				artSize = info.Size()
+			}
 			if rmErr := os.Remove(artifactPath); rmErr != nil && !os.IsNotExist(rmErr) {
 				return fmt.Errorf("remove artifact: %w", rmErr)
 			}
+			p.Observe("artifact.remove", 1, artSize)
 			d.Log.OK("removed artifact: %s", artifactPath)
 			return nil
 		}()

--- a/internal/treepad/lifecycle/lifecycle.go
+++ b/internal/treepad/lifecycle/lifecycle.go
@@ -173,6 +173,7 @@ func LoadAndSync(
 			syncRes, syncErr := d.Syncer.Sync(patterns, internalsync.Config{
 				SourceDir: sourceDir,
 				TargetDir: t.Path,
+				Stage:     p.Stage,
 			})
 			fileSyncDone()
 			p.Observe("file_sync", syncRes.Files, syncRes.Bytes)

--- a/internal/treepad/lifecycle/lifecycle.go
+++ b/internal/treepad/lifecycle/lifecycle.go
@@ -66,19 +66,35 @@ func CreateWorktreeWithSync(ctx context.Context, d deps.Deps, branch, base, outp
 	var artifactPath string
 	postErr, err := hook.RunSandwich(ctx, p, d.HookRunner, cfg.Hooks, hook.PreNew, hook.PostNew, hData, func() error {
 		addDone := p.Stage("git.worktree_add")
-		_, addErr := d.Runner.Run(ctx, "git", "worktree", "add", "-b", branch, worktreePath, base)
+		_, addErr := d.Runner.Run(ctx, "git", "worktree", "add", "--no-checkout", "-b", branch, worktreePath, base)
 		addDone()
 		if addErr != nil {
 			return fmt.Errorf("git worktree add: %w", addErr)
 		}
 		d.Log.OK("created worktree at %s", worktreePath)
 
-		var syncErr error
-		cfg, syncErr = LoadAndSync(ctx, d, rc.Main.Path, &cfg, nil,
-			[]SyncTarget{{Path: worktreePath, Branch: branch}}, rc.Slug, rc.OutputDir)
-		if syncErr != nil {
-			return syncErr
+		// git checkout and sync write disjoint paths (tracked files vs gitignored),
+		// so both can run concurrently after the worktree directory is created.
+		var newCfg config.Config
+		g, gctx := errgroup.WithContext(ctx)
+		g.Go(func() error {
+			done := p.Stage("git.checkout")
+			defer done()
+			if _, err := d.Runner.Run(gctx, "git", "-C", worktreePath, "checkout", "HEAD", "--", "."); err != nil {
+				return fmt.Errorf("git checkout: %w", err)
+			}
+			return nil
+		})
+		g.Go(func() error {
+			var err error
+			newCfg, err = LoadAndSync(gctx, d, rc.Main.Path, &cfg, nil,
+				[]SyncTarget{{Path: worktreePath, Branch: branch}}, rc.Slug, rc.OutputDir)
+			return err
+		})
+		if err := g.Wait(); err != nil {
+			return err
 		}
+		cfg = newCfg
 
 		artData := config.MakeTemplateData(rc.Slug, branch, worktreePath, rc.OutputDir)
 		artDone := p.Stage("artifact.write")

--- a/internal/treepad/lifecycle/lifecycle.go
+++ b/internal/treepad/lifecycle/lifecycle.go
@@ -176,7 +176,7 @@ func LoadAndSync(
 				Stage:     p.Stage,
 			})
 			fileSyncDone()
-			p.Observe("file_sync", syncRes.Files, syncRes.Bytes)
+			p.Observe("file_sync", syncRes.Files, 0)
 			if syncErr != nil {
 				return fmt.Errorf("sync configs to %s: %w", t.Branch, syncErr)
 			}

--- a/internal/treepad/lifecycle/new_test.go
+++ b/internal/treepad/lifecycle/new_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"slices"
 	"strings"
 	"testing"
 
@@ -19,7 +20,8 @@ func TestNew(t *testing.T) {
 	t.Run("creates worktree and syncs config", func(t *testing.T) {
 		runner := &treepadtest.SeqRunner{Responses: []treepadtest.RunResponse{
 			{Output: porcelain},
-			{Output: nil}, // git worktree add
+			{Output: nil}, // git worktree add --no-checkout
+			{Output: nil}, // git -C <path> checkout HEAD -- .
 		}}
 		syn := &treepadtest.FakeSyncer{}
 		opener := &treepadtest.FakeOpener{}
@@ -50,7 +52,8 @@ func TestNew(t *testing.T) {
 	t.Run("opens artifact when Open is true", func(t *testing.T) {
 		runner := &treepadtest.SeqRunner{Responses: []treepadtest.RunResponse{
 			{Output: porcelain},
-			{Output: nil},
+			{Output: nil}, // git worktree add --no-checkout
+			{Output: nil}, // git checkout
 		}}
 		opener := &treepadtest.FakeOpener{}
 		deps := deps.Deps{Runner: runner, Syncer: &treepadtest.FakeSyncer{}, Opener: opener}
@@ -79,7 +82,8 @@ func TestNew(t *testing.T) {
 	t.Run("emits cd directive by default", func(t *testing.T) {
 		runner := &treepadtest.SeqRunner{Responses: []treepadtest.RunResponse{
 			{Output: porcelain},
-			{Output: nil},
+			{Output: nil}, // git worktree add --no-checkout
+			{Output: nil}, // git checkout
 		}}
 		var buf strings.Builder
 		deps := deps.Deps{
@@ -103,7 +107,8 @@ func TestNew(t *testing.T) {
 	t.Run("suppresses cd directive when Current is true", func(t *testing.T) {
 		runner := &treepadtest.SeqRunner{Responses: []treepadtest.RunResponse{
 			{Output: porcelain},
-			{Output: nil},
+			{Output: nil}, // git worktree add --no-checkout
+			{Output: nil}, // git checkout
 		}}
 		var buf strings.Builder
 		deps := deps.Deps{
@@ -131,7 +136,8 @@ func TestNew(t *testing.T) {
 
 		runner := &treepadtest.SeqRunner{Responses: []treepadtest.RunResponse{
 			{Output: porcelain},
-			{Output: nil},
+			{Output: nil}, // git worktree add --no-checkout
+			{Output: nil}, // git checkout
 		}}
 		hr := &treepadtest.FakeHookRunner{}
 		deps := deps.Deps{Runner: runner, Syncer: &treepadtest.FakeSyncer{}, Opener: &treepadtest.FakeOpener{}}
@@ -187,7 +193,8 @@ func TestNew(t *testing.T) {
 
 		runner := &treepadtest.SeqRunner{Responses: []treepadtest.RunResponse{
 			{Output: porcelain},
-			{Output: nil},
+			{Output: nil}, // git worktree add --no-checkout
+			{Output: nil}, // git checkout
 		}}
 		hr := &treepadtest.FakeHookRunner{Err: errors.New("post hook failed")}
 		deps := deps.Deps{Runner: runner, Syncer: &treepadtest.FakeSyncer{}, Opener: &treepadtest.FakeOpener{}}
@@ -200,6 +207,36 @@ func TestNew(t *testing.T) {
 		})
 		if err != nil {
 			t.Errorf("PostNew hook failure should not abort operation, got error: %v", err)
+		}
+	})
+
+	t.Run("uses --no-checkout then checkout concurrently with sync", func(t *testing.T) {
+		rr := &treepadtest.RecordingRunner{Inner: &treepadtest.SeqRunner{Responses: []treepadtest.RunResponse{
+			{Output: porcelain},
+			{Output: nil}, // git worktree add --no-checkout
+			{Output: nil}, // git checkout
+		}}}
+		deps := deps.Deps{Runner: rr, Syncer: &treepadtest.FakeSyncer{}, Opener: &treepadtest.FakeOpener{}}
+
+		_, err := New(context.Background(), deps, NewInput{Branch: "feature/auth", Base: "main", OutputDir: outputDir})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var sawNoCheckout, sawCheckout bool
+		for _, call := range rr.Calls {
+			if len(call) >= 4 && call[1] == "worktree" && call[2] == "add" && call[3] == "--no-checkout" {
+				sawNoCheckout = true
+			}
+			if len(call) >= 3 && call[1] == "-C" && slices.Contains(call, "checkout") {
+				sawCheckout = true
+			}
+		}
+		if !sawNoCheckout {
+			t.Error("git worktree add should be called with --no-checkout")
+		}
+		if !sawCheckout {
+			t.Error("git -C <path> checkout should be called after worktree add")
 		}
 	})
 
@@ -230,7 +267,8 @@ func TestNew(t *testing.T) {
 			name: "sync fails",
 			runner: &treepadtest.SeqRunner{Responses: []treepadtest.RunResponse{
 				{Output: porcelain},
-				{Output: nil},
+				{Output: nil}, // git worktree add --no-checkout
+				{Output: nil}, // git checkout (runs concurrently with sync)
 			}},
 			syncer:  &treepadtest.FakeSyncer{Err: errors.New("sync failed")},
 			wantErr: "sync failed",

--- a/internal/treepad/lifecycle/stat.go
+++ b/internal/treepad/lifecycle/stat.go
@@ -1,0 +1,25 @@
+package lifecycle
+
+import (
+	"io/fs"
+	"path/filepath"
+)
+
+// statTree walks root and returns the count of non-directory entries and their
+// total byte size. Walk errors are silently skipped; the function always returns
+// whatever was counted before the error. Only called when profiling is enabled.
+func statTree(root string) (files, bytes int64) {
+	_ = filepath.WalkDir(root, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		files++
+		if d.Type().IsRegular() {
+			if info, e := d.Info(); e == nil {
+				bytes += info.Size()
+			}
+		}
+		return nil
+	})
+	return
+}

--- a/internal/treepad/treepadtest/fakes.go
+++ b/internal/treepad/treepadtest/fakes.go
@@ -54,15 +54,16 @@ func (r *RecordingRunner) Run(ctx context.Context, name string, args ...string) 
 	return r.Inner.Run(ctx, name, args...)
 }
 
-// FakeSyncer records Sync calls and returns a canned error.
+// FakeSyncer records Sync calls and returns a canned result and error.
 type FakeSyncer struct {
-	Calls []internalsync.Config
-	Err   error
+	Calls  []internalsync.Config
+	Result internalsync.SyncResult
+	Err    error
 }
 
-func (f *FakeSyncer) Sync(_ []string, cfg internalsync.Config) error {
+func (f *FakeSyncer) Sync(_ []string, cfg internalsync.Config) (internalsync.SyncResult, error) {
 	f.Calls = append(f.Calls, cfg)
-	return f.Err
+	return f.Result, f.Err
 }
 
 // FakeOpener records Open calls and returns a canned error.


### PR DESCRIPTION
## Summary

- Recovers 6 orphaned perf commits that were never merged to `main` (sub-stage profiling, skip stat-walk after `cloneTree`, MkdirAll cache, drop `Bytes` from `SyncResult`, non-Darwin budget-test skip, adaptive `--profile` table units)
- Adds the biggest remaining win: `git worktree add --no-checkout` + errgroup to run `git checkout` and `sync.clone_pass` concurrently — their write paths are disjoint (tracked files vs gitignored targets)

## Expected perf

| stage | before | after |
|---|---|---|
| `git.worktree_add` | ~2s (includes checkout) | ~ms |
| `git.checkout` | — | ~2s (new, concurrent) |
| `sync.clone_pass` | ~2s (sequential after add) | ~2s (concurrent with checkout) |
| **total wall time** | **~4s** | **~2s** |

## Test plan

- [ ] `go test -race ./...` — only pre-existing CD-sentinel failures (11), no new failures, no races
- [ ] `golangci-lint run ./...` — clean
- [ ] `tp --profile new <branch>` on a project with `node_modules/` — verify `git.worktree_add` ≈ ms, `git.checkout` and `sync.clone_pass` ≈ 2s each, total wall time ≈ 2s

🤖 Generated with [Claude Code](https://claude.com/claude-code)